### PR TITLE
adding dex routing target to testevent

### DIFF
--- a/tus/file-hooks/metadata-verify/allowed_destination_and_events.json
+++ b/tus/file-hooks/metadata-verify/allowed_destination_and_events.json
@@ -37,7 +37,8 @@
         "name": "testevent1",
         "definition_filename": "definitions/dextesting_te1_metadata_definition.json",
         "copy_targets": [ 
-          { "target" : "dex_edav"}
+          { "target" : "dex_edav"},
+          { "target" : "dex_routing"}
         ]
       }
     ]


### PR DESCRIPTION
## Updates
- allowed_destination_and_events.json
    - adding the dex routing target to the dextesting destination id