### PR TITLE
Quickfix/post finish race cond

### DIFF
--- a/tus/file-hooks/post-finish/post_finish_bin.py
+++ b/tus/file-hooks/post-finish/post_finish_bin.py
@@ -2,6 +2,7 @@ import getopt
 import logging
 import os
 import sys
+import time
 
 from dotenv import load_dotenv
 
@@ -40,4 +41,5 @@ def main(argv):
 
 
 if __name__ == '__main__':
+    time.sleep(5)
     main(sys.argv[1:])

--- a/tus/file-hooks/post-finish/post_finish_bin.py
+++ b/tus/file-hooks/post-finish/post_finish_bin.py
@@ -2,7 +2,6 @@ import getopt
 import logging
 import os
 import sys
-import time
 
 from dotenv import load_dotenv
 
@@ -41,5 +40,4 @@ def main(argv):
 
 
 if __name__ == '__main__':
-    time.sleep(5)
     main(sys.argv[1:])

--- a/tus/file-hooks/post-finish/proc_stat_controller.py
+++ b/tus/file-hooks/post-finish/proc_stat_controller.py
@@ -1,4 +1,10 @@
 import requests
+import os
+import logging
+import time
+from requests import Request, Session
+
+MAX_RETRIES = os.getenv("PS_API_MAX_RETRIES") or 4
 
 
 def _handle_trace_response(resp_json):
@@ -14,10 +20,16 @@ def _handle_span_response(resp_json):
 class ProcStatController:
     def __init__(self, url):
         self.url = url
+        self.session = Session()
+        self.retry_count = 0
+        self.logger = logging.getLogger(__name__)
+
+    def __del__(self):
+        self.session.close()
 
     def get_trace_by_upload_id(self, upload_id):
-        response = requests.get(f'{self.url}/api/trace/uploadId/{upload_id}')
-        response.raise_for_status()
+        req = Request('GET', f'{self.url}/api/trace/uploadId/{upload_id}')
+        response = self._send_request_with_retry(req.prepare())
 
         resp_json = response.json()
         _handle_trace_response(resp_json)
@@ -29,8 +41,8 @@ class ProcStatController:
             "uploadId": upload_id,
             "stageName": stage_name
         }
-        response = requests.get(f'{self.url}/api/trace/span', params=params)
-        response.raise_for_status()
+        req = Request('GET', f'{self.url}/api/trace/span', params=params)
+        response = self._send_request_with_retry(req.prepare())
 
         resp_json = response.json()
         _handle_span_response(resp_json)
@@ -38,5 +50,26 @@ class ProcStatController:
         return resp_json
 
     def stop_span_for_trace(self, trace_id, parent_span_id):
-        response = requests.put(f'{self.url}/api/trace/stopSpan/{trace_id}/{parent_span_id}')
-        response.raise_for_status()
+        req = Request('PUT', f'{self.url}/api/trace/stopSpan/{trace_id}/{parent_span_id}')
+        self._send_request_with_retry(req.prepare())
+
+    def _send_request_with_retry(self, req):
+        # Resetting the retry count.
+        self.retry_count = 0
+
+        while self.retry_count < MAX_RETRIES:
+            try:
+                resp = self.session.send(req)
+                resp.raise_for_status()
+
+                if resp.ok:
+                    # Request was handled successfully, return and don't send any more requests.
+                    return resp
+            except requests.exceptions.RequestException as e:
+                self.logger.warning(f"Error sending request to PS API after attempt {self.retry_count}.  Reason: {e}")
+                self.retry_count = self.retry_count + 1
+
+                # Waiting 1 second before trying again.
+                time.sleep(1)
+
+        raise Exception(f"Unable to send successful request to PS API after {MAX_RETRIES} attempts.")

--- a/tus/file-hooks/post-finish/proc_stat_controller.py
+++ b/tus/file-hooks/post-finish/proc_stat_controller.py
@@ -69,7 +69,7 @@ class ProcStatController:
                 self.logger.warning(f"Error sending request to PS API after attempt {self.retry_count}.  Reason: {e}")
                 self.retry_count = self.retry_count + 1
 
-                # Waiting 1 second before trying again.
-                time.sleep(1)
+                # Waiting 2 second before trying again.
+                time.sleep(2)
 
         raise Exception(f"Unable to send successful request to PS API after {MAX_RETRIES} attempts.")

--- a/tus/file-hooks/post-finish/proc_stat_controller.py
+++ b/tus/file-hooks/post-finish/proc_stat_controller.py
@@ -4,7 +4,7 @@ import logging
 import time
 from requests import Request, Session
 
-MAX_RETRIES = os.getenv("PS_API_MAX_RETRIES") or 4
+MAX_RETRIES = os.getenv("PS_API_MAX_RETRIES") or 6
 
 
 def _handle_trace_response(resp_json):
@@ -18,8 +18,9 @@ def _handle_span_response(resp_json):
 
 
 class ProcStatController:
-    def __init__(self, url):
+    def __init__(self, url, delay_s=1):
         self.url = url
+        self.delay_s = delay_s
         self.session = Session()
         self.retry_count = 0
         self.logger = logging.getLogger(__name__)
@@ -70,6 +71,6 @@ class ProcStatController:
                 self.retry_count = self.retry_count + 1
 
                 # Waiting 2 second before trying again.
-                time.sleep(2)
+                time.sleep(self.delay_s)
 
         raise Exception(f"Unable to send successful request to PS API after {MAX_RETRIES} attempts.")

--- a/tus/file-hooks/post-finish/test/test_post_finish.py
+++ b/tus/file-hooks/post-finish/test/test_post_finish.py
@@ -5,18 +5,19 @@ from post_finish_bin import post_finish
 
 
 class TestPostFinishMethods(unittest.TestCase):
-  @patch.object(ProcStatController, 'get_span_by_upload_id')
-  @patch.object(ProcStatController, 'stop_span_for_trace')
-  def test_should_send_requests_to_ps_api(self, get_span_by_upload_id_mock, stop_span_for_trace_mock):
-    get_span_by_upload_id_mock.return_value = {
-      "trace_id": "1234",
-      "span_id": "5678"
-    }
+    @patch.object(ProcStatController, 'get_span_by_upload_id')
+    @patch.object(ProcStatController, 'stop_span_for_trace')
+    def test_should_send_requests_to_ps_api(self, get_span_by_upload_id_mock, stop_span_for_trace_mock):
+        get_span_by_upload_id_mock.return_value = {
+            "trace_id": "1234",
+            "span_id": "5678"
+        }
 
-    post_finish("1234")
+        post_finish("1234")
 
-    self.assertEqual(get_span_by_upload_id_mock.call_count, 1)
-    self.assertEqual(stop_span_for_trace_mock.call_count, 1)
+        self.assertEqual(get_span_by_upload_id_mock.call_count, 1)
+        self.assertEqual(stop_span_for_trace_mock.call_count, 1)
+
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/tus/file-hooks/post-finish/test/test_proc_stat_controller.py
+++ b/tus/file-hooks/post-finish/test/test_proc_stat_controller.py
@@ -1,0 +1,28 @@
+import unittest
+from proc_stat_controller import ProcStatController
+
+
+class TestProcStatController(unittest.TestCase):
+    def test_should_retry_get_trace_when_upload_id_invalid(self):
+        controller = ProcStatController('http://dummy', .01)
+
+        with self.assertRaises(Exception) as context:
+            controller.get_trace_by_upload_id(None)
+
+        self.assertEqual(controller.retry_count, 6)
+
+    def test_should_retry_get_span_when_upload_id_invalid(self):
+        controller = ProcStatController('http://dummy', .01)
+
+        with self.assertRaises(Exception) as context:
+            controller.get_span_by_upload_id(None, 'dummy')
+
+        self.assertEqual(controller.retry_count, 6)
+
+    def test_should_retry_stop_span_when_input_invalid(self):
+        controller = ProcStatController('http://dummy', .01)
+
+        with self.assertRaises(Exception) as context:
+            controller.stop_span_for_trace(None, None)
+
+        self.assertEqual(controller.retry_count, 6)


### PR DESCRIPTION
Adds retry loop with delay for HTTP calls made to PS API.  This is to account for possible 5 second caching delay on PS API side before trace ID is available.