### PR TITLE
removed copy to edav storage for aims celr csv

### DIFF
--- a/tus/file-hooks/metadata-verify/allowed_destination_and_events.json
+++ b/tus/file-hooks/metadata-verify/allowed_destination_and_events.json
@@ -6,7 +6,6 @@
         "name": "csv",
         "definition_filename": "definitions/aims_celr_meta_definition.json",
         "copy_targets": [ 
-          { "target" : "dex_edav"},
           { "target" : "dex_routing"}
         ]
       },


### PR DESCRIPTION
## Updates

- removed routing to edav copy targets in allowed destinations and events json for AIMS CELR CSV files