### PR TITLE
Upload 932/ps api copy errors

### DIFF
--- a/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunction.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunction.cs
@@ -119,7 +119,13 @@ namespace BulkFileUploadFunctionApp
                     if (blobCreatedEvent.Data?.Url == null)
                         throw new Exception("Unexpected data content of event; no blob create event url found.");
 
-                    await ProcessBlobCreatedEvent(blobCreatedEvent.Data.Url);
+                    try
+                    {
+                        await ProcessBlobCreatedEvent(blobCreatedEvent.Data.Url);
+                    } catch (Exception ex)
+                    {
+                        ExceptionUtils.LogErrorDetails(ex, _logger);
+                    }
                 }
             } // .foreach 
 

--- a/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunction.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunction.cs
@@ -105,7 +105,6 @@ namespace BulkFileUploadFunctionApp
 
                 StorageBlobCreatedEvent[]? blobCreatedEvents = JsonConvert.DeserializeObject<StorageBlobCreatedEvent[]>(blobCreatedEventJson);
 
-                // TODO: PS API fail report if any of these conditions are true.
                 if (blobCreatedEvents == null)
                     throw new Exception("Unexpected data content of event; unable to establish a StorageBlobCreatedEvent array");
 
@@ -185,7 +184,8 @@ namespace BulkFileUploadFunctionApp
                 catch (RequestFailedException ex)
                 {
                     ExceptionUtils.LogErrorDetails(ex, _logger);
-                    // TODO: Send failure report to PS API.
+                    CopyReport failReport = new CopyReport(sourceUrl: blobCreatedUrl, destUrl: destinationContainerName, result: "failure", errorDesc: $"Failed to copy from Tus to DEX. {ex.Message}");
+                    await _procStatClient.CreateReport(tusInfoFile.ID, destinationId, eventType, Constants.PROC_STAT_REPORT_STAGE_NAME, failReport);
                     throw new Exception("Failed to copy from Tus to DEX.  Aborting attempt to copy to destination storage accounts.");
                 }
 
@@ -226,7 +226,8 @@ namespace BulkFileUploadFunctionApp
                     {
                         _logger.LogError("Failed to copy from Dex to Edav");
                         ExceptionUtils.LogErrorDetails(ex, _logger);
-                        // TODO: Send failure report to PS API.
+                        CopyReport failReport = new CopyReport(sourceUrl: sourceBlobUrl, destUrl: destinationContainerName, result: "failure", errorDesc: $"Failed to copy from Tus to DEX. {ex.Message}");
+                        await _procStatClient.CreateReport(uploadId, destinationId, eventType, Constants.PROC_STAT_REPORT_STAGE_NAME, failReport);
                     }
                     catch (HttpRequestException ex)
                     {
@@ -250,7 +251,8 @@ namespace BulkFileUploadFunctionApp
                         {
                             _logger.LogError("Failed to copy from Dex to ROUTING");
                             ExceptionUtils.LogErrorDetails(ex, _logger);
-                            // TODO: Send failure report to PS API.
+                            CopyReport failReport = new CopyReport(sourceUrl: sourceBlobUrl, destUrl: destinationContainerName, result: "failure", errorDesc: $"Failed to copy from Tus to DEX. {ex.Message}");
+                            await _procStatClient.CreateReport(uploadId, destinationId, eventType, Constants.PROC_STAT_REPORT_STAGE_NAME, failReport);
                         }
                         catch (HttpRequestException ex)
                         {

--- a/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.csproj
+++ b/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.csproj
+++ b/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.csproj
@@ -7,12 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.2" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.14.1" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.8.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.Functions.Worker" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.10.1" />

--- a/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.sln
+++ b/upload-processor/BulkFileUploadFunctionApp/BulkFileUploadFunctionApp.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33209.295
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BulkFileUploadFunctionApp", "BulkFileUploadFunctionApp.csproj", "{F203B38F-880E-4F21-9B30-03786BA903CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BulkFileUploadFunctionApp", "BulkFileUploadFunctionApp.csproj", "{F203B38F-880E-4F21-9B30-03786BA903CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BulkFileUploadFunctionAppTest", "..\BulkFileUploadFunctionAppTest\BulkFileUploadFunctionAppTest.csproj", "{DE7ED07D-035F-4F1E-89FB-AAF271ABBCFB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{F203B38F-880E-4F21-9B30-03786BA903CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F203B38F-880E-4F21-9B30-03786BA903CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F203B38F-880E-4F21-9B30-03786BA903CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE7ED07D-035F-4F1E-89FB-AAF271ABBCFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE7ED07D-035F-4F1E-89FB-AAF271ABBCFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE7ED07D-035F-4F1E-89FB-AAF271ABBCFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE7ED07D-035F-4F1E-89FB-AAF271ABBCFB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/upload-processor/BulkFileUploadFunctionApp/Model/CopyReport.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/CopyReport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BulkFileUploadFunctionApp.Utils;
 using Newtonsoft.Json;
 
 namespace BulkFileUploadFunctionApp.Model
@@ -12,7 +13,7 @@ namespace BulkFileUploadFunctionApp.Model
 
         public CopyReport(string sourceUrl, string destUrl, string result, string? errorDesc, string? schemaVersion)
         {
-            this.SchemaName = "dex-file-copy";
+            this.SchemaName = Constants.PROC_STAT_REPORT_STAGE_NAME;
             this.FileSourceBlobUrl = sourceUrl;
             this.FileDestinationBlobUrl = destUrl;
             this.Result = result;
@@ -27,7 +28,7 @@ namespace BulkFileUploadFunctionApp.Model
         // TODO: add success fail enum and verification.
         public CopyReport(string sourceUrl, string destUrl, string result)
         {
-            this.SchemaName = "dex-file-copy";
+            this.SchemaName = Constants.PROC_STAT_REPORT_STAGE_NAME;
             this.FileSourceBlobUrl = sourceUrl;
             this.FileDestinationBlobUrl = destUrl;
             this.Result = result;
@@ -35,7 +36,7 @@ namespace BulkFileUploadFunctionApp.Model
         }
         public CopyReport(string sourceUrl, string destUrl, string result, string? errorDesc)
         {
-            this.SchemaName = "dex-file-copy";
+            this.SchemaName = Constants.PROC_STAT_REPORT_STAGE_NAME;
             this.FileSourceBlobUrl = sourceUrl;
             this.FileDestinationBlobUrl = destUrl;
             this.Result = result;

--- a/upload-processor/BulkFileUploadFunctionApp/Model/CopyReport.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/CopyReport.cs
@@ -31,7 +31,17 @@ namespace BulkFileUploadFunctionApp.Model
             this.FileSourceBlobUrl = sourceUrl;
             this.FileDestinationBlobUrl = destUrl;
             this.Result = result;
-            this.SchemaVersion = Report.DEFAULT_SCHEMA_VERSION;
+            this.SchemaVersion = DEFAULT_SCHEMA_VERSION;
         }
+        public CopyReport(string sourceUrl, string destUrl, string result, string? errorDesc)
+        {
+            this.SchemaName = "dex-file-copy";
+            this.FileSourceBlobUrl = sourceUrl;
+            this.FileDestinationBlobUrl = destUrl;
+            this.Result = result;
+            this.ErrorDescription = errorDesc;
+            this.SchemaVersion = DEFAULT_SCHEMA_VERSION;
+        }
+
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Model/HealthCheckResponse.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/HealthCheckResponse.cs
@@ -1,4 +1,3 @@
-
 namespace BulkFileUploadFunctionApp.Model
 {
     public class HealthCheckResponse
@@ -6,5 +5,16 @@ namespace BulkFileUploadFunctionApp.Model
         public string Status { get; set; }
         public string TotalChecksDuration { get; set; } // Duration of all health checks combined.
         public List<HealthCheckResult> DependencyHealthChecks { get; set; } = new();  // Results of individual dependency health checks.
+
+        public HealthCheckResult ToHealthCheckResult(string serviceName)
+        {
+            HealthCheckResult result = new HealthCheckResult(serviceName, Status);
+
+            // Aggregate health issues from dependent health checks.
+            string healthIssues = string.Join(",", DependencyHealthChecks.Select(check => check.HealthIssues));
+            result.HealthIssues = healthIssues;
+
+            return result;
+        }
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration;
+using Microsoft.FeatureManagement;
+using System;
+using Microsoft.Extensions.Configuration;
+
+namespace BulkFileUploadFunctionApp.Services
+{
+    public class FeatureManagementExecutor : IFeatureManagementExecutor
+    {
+        private readonly IConfigurationRefresher _configurationRefresher;
+        private readonly IConfiguration _configuration;
+
+        public FeatureManagementExecutor(IConfigurationRefresherProvider configurationRefresherProvider, IConfiguration configuration) 
+        {
+            _configurationRefresher = configurationRefresherProvider.Refreshers.First();
+            _configuration = configuration;
+        }
+        public IFeatureManagementExecutor ExecuteIfEnabledAsync(string flagName, Action callback)
+        {
+            _configurationRefresher.TryRefreshAsync();
+            bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");
+
+            if (isEnabled)
+            {
+                callback();
+            }
+
+            return this;
+        }
+
+        public IFeatureManagementExecutor ExecuteIfDisabledAsync(string flagName, Action callback)
+        {
+            _configurationRefresher.TryRefreshAsync();
+            bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");
+
+            if (!isEnabled)
+            {
+                callback();
+            }
+
+            return this;
+        }
+    }
+}

--- a/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
@@ -15,10 +15,12 @@ namespace BulkFileUploadFunctionApp.Services
             _configurationRefresher = configurationRefresherProvider.Refreshers.First();
             _configuration = configuration;
         }
-        public IFeatureManagementExecutor ExecuteIfEnabledAsync(string flagName, Action callback)
+
+        public IFeatureManagementExecutor ExecuteIfEnabled(string flagName, Action callback)
         {
             _configurationRefresher.TryRefreshAsync();
             bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");
+
 
             if (isEnabled)
             {
@@ -28,7 +30,34 @@ namespace BulkFileUploadFunctionApp.Services
             return this;
         }
 
-        public IFeatureManagementExecutor ExecuteIfDisabledAsync(string flagName, Action callback)
+        public async Task<IFeatureManagementExecutor> ExecuteIfEnabledAsync(string flagName, Func<Task> callback)
+        {
+            await _configurationRefresher.TryRefreshAsync();
+            bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");
+
+
+            if (isEnabled)
+            {
+                await callback();
+            }
+
+            return this;
+        }
+
+        public async Task<IFeatureManagementExecutor> ExecuteIfDisabledAsync(string flagName, Func<Task> callback)
+        {
+            await _configurationRefresher.TryRefreshAsync();
+            bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");
+
+            if (!isEnabled)
+            {
+                await callback();
+            }
+
+            return this;
+        }
+
+        public IFeatureManagementExecutor ExecuteIfDisabled(string flagName, Action callback)
         {
             _configurationRefresher.TryRefreshAsync();
             bool isEnabled = _configuration.GetValue<bool>($"FeatureManagement:{flagName}");

--- a/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/FeatureManagementExecutor.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.Extensions.Configuration.AzureAppConfiguration;
-using Microsoft.FeatureManagement;
-using System;
 using Microsoft.Extensions.Configuration;
 
 namespace BulkFileUploadFunctionApp.Services

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IFeatureManagementExecutor.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IFeatureManagementExecutor.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BulkFileUploadFunctionApp.Services
+{
+    public interface IFeatureManagementExecutor
+    {
+        public IFeatureManagementExecutor ExecuteIfEnabledAsync(string flagName, Action callback);
+        public IFeatureManagementExecutor ExecuteIfDisabledAsync(string flagName, Action callback);
+    }
+}

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IFeatureManagementExecutor.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IFeatureManagementExecutor.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BulkFileUploadFunctionApp.Services
+﻿namespace BulkFileUploadFunctionApp.Services
 {
     public interface IFeatureManagementExecutor
     {
-        public IFeatureManagementExecutor ExecuteIfEnabledAsync(string flagName, Action callback);
-        public IFeatureManagementExecutor ExecuteIfDisabledAsync(string flagName, Action callback);
+        public Task<IFeatureManagementExecutor> ExecuteIfEnabledAsync(string flagName, Func<Task> callback);
+        public IFeatureManagementExecutor ExecuteIfEnabled(string flagName, Action callback);
+        public Task<IFeatureManagementExecutor> ExecuteIfDisabledAsync(string flagName, Func<Task> callback);
+        public IFeatureManagementExecutor ExecuteIfDisabled(string flagName, Action callback);
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
@@ -5,7 +5,7 @@ namespace BulkFileUploadFunctionApp.Services
 {
     public interface IProcStatClient
     {
-        Task<string> GetHealthCheck();
+        Task<HealthCheckResponse> GetHealthCheck();
         Task<Trace> GetTraceByUploadId(string uploadId);
         Task<Span> StartSpanForTrace(string traceId, string parentSpanId, string stageName);
         Task<string> StopSpanForTrace(string traceId, string parentSpanId);

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
@@ -8,7 +8,7 @@ namespace BulkFileUploadFunctionApp.Services
         Task<HealthCheckResponse> GetHealthCheck();
         Task<Trace?> GetTraceByUploadId(string uploadId);
         Task<Span?> StartSpanForTrace(string traceId, string parentSpanId, string stageName);
-        Task<string> StopSpanForTrace(string traceId, string parentSpanId);
+        Task<string?> StopSpanForTrace(string traceId, string parentSpanId);
         Task<bool> CreateReport(string uploadId, string destinationId, string eventType, string stageName, CopyReport payload);
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
@@ -9,6 +9,6 @@ namespace BulkFileUploadFunctionApp.Services
         Task<Trace> GetTraceByUploadId(string uploadId);
         Task<Span> StartSpanForTrace(string traceId, string parentSpanId, string stageName);
         Task<string> StopSpanForTrace(string traceId, string parentSpanId);
-        Task CreateReport(string uploadId, string destinationId, string eventType, string stageName, CopyReport payload);
+        Task<bool> CreateReport(string uploadId, string destinationId, string eventType, string stageName, CopyReport payload);
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/IProcStatClient.cs
@@ -6,8 +6,8 @@ namespace BulkFileUploadFunctionApp.Services
     public interface IProcStatClient
     {
         Task<HealthCheckResponse> GetHealthCheck();
-        Task<Trace> GetTraceByUploadId(string uploadId);
-        Task<Span> StartSpanForTrace(string traceId, string parentSpanId, string stageName);
+        Task<Trace?> GetTraceByUploadId(string uploadId);
+        Task<Span?> StartSpanForTrace(string traceId, string parentSpanId, string stageName);
         Task<string> StopSpanForTrace(string traceId, string parentSpanId);
         Task<bool> CreateReport(string uploadId, string destinationId, string eventType, string stageName, CopyReport payload);
     }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
@@ -89,21 +89,48 @@ namespace BulkFileUploadFunctionApp.Services
 
         public async Task<Span?> StartSpanForTrace(string traceId, string parentSpanId, string stageName)
         {
-            var response = await _httpClient.PutAsync($"/api/trace/startSpan/{traceId}/{parentSpanId}?stageName={stageName}", null);
-            response.EnsureSuccessStatusCode();
+            try
+            {
+                var response = await _httpClient.PutAsync($"/api/trace/startSpan/{traceId}/{parentSpanId}?stageName={stageName}", null);
+                response.EnsureSuccessStatusCode();
 
-            var responseBody = await response.Content.ReadAsStringAsync();
-            // TODO: Handle empty body.
-            return JsonConvert.DeserializeObject<Span>(responseBody);
+                var responseBody = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrEmpty(responseBody))
+                {
+                    _logger.LogError("Call to PS API returned empty body.");
+                    return null;
+                }
+                return JsonConvert.DeserializeObject<Span>(responseBody);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error when calling PS API.");
+                ExceptionUtils.LogErrorDetails(ex, _logger);
+                return null;
+            }
         }
 
-        public async Task<string> StopSpanForTrace(string traceId, string childSpanId)
+        public async Task<string?> StopSpanForTrace(string traceId, string childSpanId)
         {
-            var response = await _httpClient.PutAsync($"/api/trace/stopSpan/{traceId}/{childSpanId}", null);
-            response.EnsureSuccessStatusCode();
+            try
+            {
+                var response = await _httpClient.PutAsync($"/api/trace/stopSpan/{traceId}/{childSpanId}", null);
+                response.EnsureSuccessStatusCode();
 
-            var responseBody = await response.Content.ReadAsStringAsync();
-            return responseBody;
+                var responseBody = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrEmpty(responseBody))
+                {
+                    _logger.LogError("Call to PS API returned empty body.");
+                    return null;
+                }
+                return responseBody;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Error when calling PS API.");
+                ExceptionUtils.LogErrorDetails(ex, _logger);
+                return null;
+            }
         }
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
@@ -9,7 +9,6 @@ namespace BulkFileUploadFunctionApp.Services
     public class ProcStatClient : IProcStatClient
     {
         private readonly HttpClient _httpClient;
-        private readonly string _remoteServiceBaseUrl;
         private readonly ILogger<ProcStatClient> _logger;
 
         public ProcStatClient(HttpClient httpClient, ILogger<ProcStatClient> logger)

--- a/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
@@ -11,7 +11,9 @@ namespace BulkFileUploadFunctionApp.Services
         private readonly HttpClient _httpClient;
         private readonly ILogger<ProcStatClient> _logger;
 
-        public ProcStatClient(HttpClient httpClient, ILogger<ProcStatClient> logger)
+        public ProcStatClient(
+            HttpClient httpClient, 
+            ILogger<ProcStatClient> logger)
         {
             _httpClient = httpClient;
             _logger = logger;

--- a/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/ProcStatClient.cs
@@ -19,13 +19,14 @@ namespace BulkFileUploadFunctionApp.Services
             _logger = logger;
         }
 
-        public async Task<string> GetHealthCheck()
+        public async Task<HealthCheckResponse> GetHealthCheck()
         {
             var response = await _httpClient.GetAsync("/api/health");
             response.EnsureSuccessStatusCode();
 
             var responseBody = await response.Content.ReadAsStringAsync();
-            return responseBody;
+            // TODO: Handle empty body.
+            return JsonConvert.DeserializeObject<HealthCheckResponse>(responseBody);
         }
         public async Task CreateReport(string uploadId, string destinationId, string eventType, string stageName, CopyReport payload)
         {

--- a/upload-processor/BulkFileUploadFunctionApp/Utils/Constants.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Utils/Constants.cs
@@ -1,13 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BulkFileUploadFunctionApp.Utils
 {
     public static class Constants
     {
         public static readonly string PROC_STAT_REPORT_STAGE_NAME = "dex-file-copy";
+        public static readonly string PROC_STAT_FEATURE_FLAG_NAME = "PROCESSING_STATUS";
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Utils/Constants.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Utils/Constants.cs
@@ -6,5 +6,6 @@ namespace BulkFileUploadFunctionApp.Utils
     {
         public static readonly string PROC_STAT_REPORT_STAGE_NAME = "dex-file-copy";
         public static readonly string PROC_STAT_FEATURE_FLAG_NAME = "PROCESSING_STATUS";
+        public static readonly string PROC_STAT_SERVICE_NAME = "Processing Status API";
     }
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Utils/HealthCheckResultUtil.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Utils/HealthCheckResultUtil.cs
@@ -87,7 +87,7 @@ namespace BulkFileUploadFunctionApp.Utils
             catch (RequestFailedException ex)
             {
                 // In case of any exceptions, consider the destination down and return the error message.
-                _logger.LogError(ex, "Error occurred while checking {containerName} container health.");
+                _logger.LogError(ex, $"Error occurred while checking {containerName} container health.");
                 return new HealthCheckResult(destination, "DOWN", "Unhealthy");
             }
         }

--- a/upload-processor/BulkFileUploadFunctionAppTest/BulkFileUploadFunctionAppTest.csproj
+++ b/upload-processor/BulkFileUploadFunctionAppTest/BulkFileUploadFunctionAppTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/upload-processor/BulkFileUploadFunctionAppTest/HealthCheckFunctionTests.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/HealthCheckFunctionTests.cs
@@ -53,10 +53,10 @@ namespace BulkFileUploadFunctionAppTests
             {
                 {$"FeatureManagement:{Constants.PROC_STAT_FEATURE_FLAG_NAME}", "true"}
             }).Build();
+            _configurationRefresherProviderMock.Setup(m => m.Refreshers).Returns(new List<IConfigurationRefresher> { _configurationRefresherMock.Object });
             _testFeatureManagementExecutor = new FeatureManagementExecutor(_configurationRefresherProviderMock.Object, _testConfiguration);
 
             // Setup mocks.
-            _configurationRefresherProviderMock.Setup(m => m.Refreshers).Returns(new List<IConfigurationRefresher>{_configurationRefresherMock.Object});
             _mockEnvironmentVariableProvider.Setup(m => m.GetEnvironmentVariable(It.IsAny<string>())).Returns("test");
             _mockFunctionContext.Setup(ctx => ctx.InstanceServices)
                                 .Returns(_mockServiceProvider.Object);

--- a/upload-processor/BulkFileUploadFunctionAppTest/HealthCheckFunctionTests.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/HealthCheckFunctionTests.cs
@@ -26,6 +26,8 @@ namespace BulkFileUploadFunctionAppTests
         private Mock<IServiceProvider> _mockServiceProvider;
         private Mock<ILogger<HealthCheckFunction>> _loggerMock;
         private Mock<ILoggerFactory> _loggerFactoryMock;
+        private Mock<IFeatureManagementExecutor> _featureManagementExecutorMock;
+        private Mock<IProcStatClient> _procStatClientMock;
 
 
         // Initializes mock objects for HTTP request/response, function context, blob service, environment variables, and logger.
@@ -49,10 +51,15 @@ namespace BulkFileUploadFunctionAppTests
             _loggerFactoryMock = new Mock<ILoggerFactory>();
             _loggerMock = new Mock<ILogger<HealthCheckFunction>>();
             _loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(_loggerMock.Object);
+            _procStatClientMock = new Mock<IProcStatClient>();
+            _featureManagementExecutorMock = new Mock<IFeatureManagementExecutor>();
 
-            // Assuming you need to set up your logger mock, for example:
             _mockServiceProvider.Setup(provider => provider.GetService(typeof(ILogger<HealthCheckFunction>)))
                                 .Returns(_loggerMock.Object);
+            _mockServiceProvider.Setup(provider => provider.GetService(typeof(IFeatureManagementExecutor)))
+                .Returns(_featureManagementExecutorMock.Object);
+            _mockServiceProvider.Setup(provider => provider.GetService(typeof(IProcStatClient)))
+                .Returns(_procStatClientMock.Object);
         }
 
         private HealthCheckFunction CreateHealthCheckFunction()
@@ -60,7 +67,9 @@ namespace BulkFileUploadFunctionAppTests
             return new HealthCheckFunction(
                 _mockBlobServiceClientFactory.Object,
                 _mockEnvironmentVariableProvider.Object,
-                _loggerFactoryMock.Object);
+                _loggerFactoryMock.Object,
+                _featureManagementExecutorMock.Object,
+                _procStatClientMock.Object);
         }
 
         [TestMethod]

--- a/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
@@ -112,5 +112,62 @@ namespace BulkFileUploadFunctionAppTest
 
             Assert.IsFalse(response);
         }
+
+        [TestMethod]
+        public async Task GivenSuccessfulResponse_WhenGetTraceByUploadId_ThenReturnsTrace()
+        {
+            // Arrange.
+            var responseBody = new Trace
+            {
+                TraceId = "1234"
+            };
+            var apiResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(responseBody))
+            };
+            var httpClient = new HttpClient(new MockedHttpMessageHandler(apiResponse))
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+            var client = new ProcStatClient(httpClient, _mockLogger.Object);
+
+            // Act.
+            var response = await client.GetTraceByUploadId("5678");
+
+            Assert.AreEqual("1234", response.TraceId);
+        }
+
+        [TestMethod]
+        public async Task GivenNullResponseContent_WhenGetTraceByUploadId_ThenReturnsNull()
+        {
+            // Arrange.
+            var apiResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            var httpClient = new HttpClient(new MockedHttpMessageHandler(apiResponse))
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+            var client = new ProcStatClient(httpClient, _mockLogger.Object);
+
+            // Act.
+            var response = await client.GetTraceByUploadId("5678");
+
+            Assert.IsNull(response);
+        }
+
+        [TestMethod]
+        public async Task GivenException_WhenGetTraceByUploadId_ThenReturnsNull()
+        {
+            // Arrange.
+            var httpClient = new HttpClient(new MockedHttpMessageHandler(() => throw new HttpRequestException()))
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+            var client = new ProcStatClient(httpClient, _mockLogger.Object);
+
+            // Act.
+            var response = await client.GetTraceByUploadId("5678");
+
+            Assert.IsNull(response);
+        }
     }
 }

--- a/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
@@ -1,0 +1,49 @@
+﻿using BulkFileUploadFunctionApp;
+using BulkFileUploadFunctionApp.Model;
+using BulkFileUploadFunctionApp.Services;
+using BulkFileUploadFunctionAppTest.utils;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace BulkFileUploadFunctionAppTest
+{
+
+    [TestClass]
+    public class ProcStatClientTest
+    {
+        private Mock<ILogger<ProcStatClient>> _mockLogger;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _mockLogger = new Mock<ILogger<ProcStatClient>>();
+        }
+
+        [TestMethod]
+        public async Task GivenSuccessfulResponse_WhenGetHealthCheck_ThenReturnsOk()
+        {
+            // Arrange.
+            var request = new HttpRequestMessage(HttpMethod.Get, "/api/health");
+            var responseBody = new HealthCheckResponse
+            {
+                Status = "UP"
+            };
+            var apiResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(responseBody))
+            };
+            var httpClient = new HttpClient(new MockedHttpMessageHandler(apiResponse))
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+            var client = new ProcStatClient(httpClient, _mockLogger.Object);
+
+            // Act.
+            var response = await client.GetHealthCheck();
+
+            Assert.AreEqual("UP", response.Status);
+        }
+
+    }
+}

--- a/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/ProcStatClientTest.cs
@@ -226,5 +226,26 @@ namespace BulkFileUploadFunctionAppTest
 
             Assert.IsNull(response);
         }
+
+        [TestMethod]
+        public async Task GivenSuccessfulResponse_WhenStopSpanForTrace_ThenReturnsId()
+        {
+            // Arrange.
+            var responseBody = "1234";
+            var apiResponse = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseBody)
+            };
+            var httpClient = new HttpClient(new MockedHttpMessageHandler(apiResponse))
+            {
+                BaseAddress = new Uri("http://localhost")
+            };
+            var client = new ProcStatClient(httpClient, _mockLogger.Object);
+
+            // Act.
+            var response = await client.StopSpanForTrace("abcd", "defg");
+
+            Assert.AreEqual("1234", response);
+        }
     }
 }

--- a/upload-processor/BulkFileUploadFunctionAppTest/utils/MockedHttpMessageHandler.cs
+++ b/upload-processor/BulkFileUploadFunctionAppTest/utils/MockedHttpMessageHandler.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BulkFileUploadFunctionAppTest.utils
+{
+    public class MockedHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<Task<HttpResponseMessage>> _responseFactory;
+        private readonly HttpResponseMessage _httpResponseMessage;
+
+        public MockedHttpMessageHandler(HttpResponseMessage httpResponseMessage)
+        {
+            _httpResponseMessage = httpResponseMessage;
+        }
+
+        public MockedHttpMessageHandler(Func<Task<HttpResponseMessage>> responseFactory)
+        {
+            _responseFactory = responseFactory ?? throw new ArgumentNullException(nameof(responseFactory));
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_responseFactory != null)
+            {
+                return await _responseFactory.Invoke();
+            }
+
+            return _httpResponseMessage;
+        }
+    }
+
+}


### PR DESCRIPTION
Sends failure reports to PS API when a copy of a file to a destination storage container fails.  To test this, you can update the code on this branch to invalidate one of the edav or routing connection strings.  You can then deploy the code to the dev function app.  Then, you can upload a file, and then query the PS API report endpoint using the file upload ID.  You should see failure reports for the `dex-file-copy` stage.

This PR also introduces a helper utility for handling feature flag checking.