### PR TITLE
Upload 1034/file copy consistency

### DIFF
--- a/tests/integration/kotlin/src/test/kotlin/ProcStat.kt
+++ b/tests/integration/kotlin/src/test/kotlin/ProcStat.kt
@@ -143,7 +143,7 @@ class ProcStat {
         val uploadReport = jsonPath.getList("reports", Report::class.java).find { it.stageName == "dex-upload" }
 
         assertNotNull(uploadReport)
-        assertEquals(uploadReport.content.size, uploadReport.content.offset)
+        assertEquals(uploadReport!!.content.size, uploadReport.content.offset)
     }
 
     @BeforeGroups(groups = [Constants.Groups.PROC_STAT_UPLOAD_STATUS_DEX_FILE_COPY_HAPPY_PATH])

--- a/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
@@ -41,25 +41,23 @@ namespace BulkFileUploadFunctionApp.Services
 
         public UploadProcessingService(ILoggerFactory loggerFactory, IProcStatClient procStatClient, IFeatureManagementExecutor featureManagementExecutor, IUploadEventHubService uploadEventHubService)
         {
-            _logger = loggerFactory.CreateLogger<UploadProcessingService>();
-            _blobCopyHelper = new(_logger);
-
-            _featureManagementExecutor = featureManagementExecutor;
-            _procStatClient = procStatClient;
-
+            // Initialize private fields from environment variables.
             _tusAzureObjectPrefix = Environment.GetEnvironmentVariable("TUS_AZURE_OBJECT_PREFIX", EnvironmentVariableTarget.Process) ?? "tus-prefix";
             _tusAzureStorageContainer = Environment.GetEnvironmentVariable("TUS_AZURE_STORAGE_CONTAINER", EnvironmentVariableTarget.Process) ?? "bulkuploads";
             _dexAzureStorageAccountName = Environment.GetEnvironmentVariable("DEX_AZURE_STORAGE_ACCOUNT_NAME", EnvironmentVariableTarget.Process) ?? "";
             _dexAzureStorageAccountKey = Environment.GetEnvironmentVariable("DEX_AZURE_STORAGE_ACCOUNT_KEY", EnvironmentVariableTarget.Process) ?? "";
             _edavAzureStorageAccountName = Environment.GetEnvironmentVariable("EDAV_AZURE_STORAGE_ACCOUNT_NAME", EnvironmentVariableTarget.Process) ?? "";
-
             _routingStorageAccountName = Environment.GetEnvironmentVariable("ROUTING_STORAGE_ACCOUNT_NAME", EnvironmentVariableTarget.Process) ?? "";
             _routingStorageAccountKey = Environment.GetEnvironmentVariable("ROUTING_STORAGE_ACCOUNT_KEY", EnvironmentVariableTarget.Process) ?? "";
-
             _edavUploadRootContainerName = Environment.GetEnvironmentVariable("EDAV_UPLOAD_ROOT_CONTAINER_NAME", EnvironmentVariableTarget.Process) ?? "upload";
             _routingUploadRootContainerName = Environment.GetEnvironmentVariable("ROUTING_UPLOAD_ROOT_CONTAINER_NAME", EnvironmentVariableTarget.Process) ?? "routeingress";
-
             _tusHooksFolder = Environment.GetEnvironmentVariable("TUSD_HOOKS_FOLDER", EnvironmentVariableTarget.Process) ?? "tusd-file-hooks";
+
+            // Instantiate helper services.
+            _logger = loggerFactory.CreateLogger<UploadProcessingService>();
+            _blobCopyHelper = new(_logger);
+            _featureManagementExecutor = featureManagementExecutor;
+            _procStatClient = procStatClient;
 
             _destinationAndEvents = GetAllDestinationAndEvents();
 

--- a/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
@@ -213,7 +213,7 @@ namespace BulkFileUploadFunctionApp.Services
                 // Get a BlobClient representing the destination blob with a unique name.
                 BlobClient destBlob = destinationContainerClient.GetBlobClient(copyPrereqs.DexBlobFileName);
 
-                await _blobCopyHelper.CopyBlobAsync(sourceBlob, destBlob, copyPrereqs.Metadata);
+                await _blobCopyHelper.CopyBlobLeaseAsync(sourceBlob, destBlob, copyPrereqs.Metadata);
 
                 return destBlob.Uri.ToString();
             }
@@ -302,7 +302,7 @@ namespace BulkFileUploadFunctionApp.Services
 
                 BlobClient destBlobClient = destContainerClient.GetBlobClient(destinationFilename);
 
-                await _blobCopyHelper.CopyBlobAsync(sourceBlobClient, destBlobClient, copyPrereqs.Metadata);
+                await _blobCopyHelper.CopyBlobStreamAsync(sourceBlobClient, destBlobClient, copyPrereqs.Metadata);
 
                 // Send copy success report
                 await _featureManagementExecutor.ExecuteIfEnabledAsync(Constants.PROC_STAT_FEATURE_FLAG_NAME, async () =>
@@ -356,7 +356,7 @@ namespace BulkFileUploadFunctionApp.Services
 
                 BlobClient destBlobClient = destContainerClient.GetBlobClient(destinationFilename);
 
-                await _blobCopyHelper.CopyBlobAsync(sourceBlobClient, destBlobClient, copyPrereqs.Metadata);
+                await _blobCopyHelper.CopyBlobStreamAsync(sourceBlobClient, destBlobClient, copyPrereqs.Metadata);
 
                 // Send copy success report
                 await _featureManagementExecutor.ExecuteIfEnabledAsync(Constants.PROC_STAT_FEATURE_FLAG_NAME, async () =>

--- a/upload-processor/BulkFileUploadFunctionApp/Utils/BlobCopyHelper.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Utils/BlobCopyHelper.cs
@@ -20,11 +20,12 @@ namespace BulkFileUploadFunctionApp.Utils
             // Lease the source blob for the copy operation 
             // to prevent another client from modifying it.
             BlobLeaseClient lease = sourceBlob.GetBlobLeaseClient();
-            // Get the source blob's properties and display the lease state.
-            BlobProperties sourceProperties = await sourceBlob.GetPropertiesAsync();
-
+            
             try
             {
+                // Get the source blob's properties and display the lease state.
+                BlobProperties sourceProperties = await sourceBlob.GetPropertiesAsync();
+
                 _logger.LogInformation($"Checking if source blob with uri {sourceBlob.Uri} exists");
 
                 // Ensure that the source blob exists.
@@ -61,7 +62,7 @@ namespace BulkFileUploadFunctionApp.Utils
             }
             finally
             {
-                sourceProperties = await sourceBlob.GetPropertiesAsync();
+                BlobProperties sourceProperties = await sourceBlob.GetPropertiesAsync();
                 _logger.LogInformation($"Post-copy Lease state: {sourceProperties.LeaseState}");
 
                 if (sourceProperties.LeaseState == LeaseState.Leased)


### PR DESCRIPTION
This effort ultimately turned out to be a failure.  It was discovered that in order to copy a file across storage accounts using a scheduled lease (as opposed to streams), the storage account needs to be publicly accessible, or a SAS token with appropriate privileges is being used.  Neither of these approaches are options for the Upload API as they go against the CDC security policy for Azure storage.

I did, however, find some ways to clean up the code in a marginal amount and wanted to get that reviewed and merged anyway.