### PR TITLE
test for invalid filename and nonhappy path prop files

### DIFF
--- a/tests/integration/kotlin/src/test/kotlin/MetadataVerify.kt
+++ b/tests/integration/kotlin/src/test/kotlin/MetadataVerify.kt
@@ -51,12 +51,19 @@ class MetadataVerify {
         Assert.assertNotNull(uploadId)
     }
 
-    @Test(groups = [Constants.Groups.METADATA_VERIFY], expectedExceptions = [ProtocolException::class])
+    @Test(
+        groups = [Constants.Groups.METADATA_VERIFY],
+        expectedExceptions = [ProtocolException::class],
+        expectedExceptionsMessageRegExp = ".*Missing one or more required metadata fields.*")
     fun shouldReturnErrorWhenDestinationIDNotProvided() {
         uploadClient.uploadFile(testFile, metadataNoDestId)
     }
 
-    @Test(groups = [Constants.Groups.METADATA_VERIFY], expectedExceptions = [ProtocolException::class])
+    @Test(
+        groups = [Constants.Groups.METADATA_VERIFY],
+        expectedExceptions = [ProtocolException::class],
+        expectedExceptionsMessageRegExp = ".*Missing one or more required metadata fields.*"
+    )
     fun shouldReturnErrorWhenEventNotProvided() {
         uploadClient.uploadFile(testFile, metadataNoEvent)
     }

--- a/tests/integration/kotlin/src/test/kotlin/MetadataVerify.kt
+++ b/tests/integration/kotlin/src/test/kotlin/MetadataVerify.kt
@@ -68,7 +68,11 @@ class MetadataVerify {
         uploadClient.uploadFile(testFile, metadataNoEvent)
     }
 
-    @Test(groups = [Constants.Groups.METADATA_VERIFY], expectedExceptions = [ProtocolException::class])
+    @Test(groups = [
+        Constants.Groups.METADATA_VERIFY],
+        expectedExceptions = [ProtocolException::class],
+        expectedExceptionsMessageRegExp = ".*Missing required metadata .*filename.*"
+    )
     fun shouldReturnErrorWhenFilenameNotProvided() {
         val metadata = hashMapOf(
             "meta_destination_id" to TEST_DESTINATION,
@@ -79,7 +83,11 @@ class MetadataVerify {
         uploadClient.uploadFile(testFile, metadata)
     }
 
-    @Test(groups = [Constants.Groups.METADATA_VERIFY], expectedExceptions = [ProtocolException::class])
+    @Test(groups = [
+        Constants.Groups.METADATA_VERIFY],
+        expectedExceptions = [ProtocolException::class],
+        expectedExceptionsMessageRegExp = ".*Filename .* contains invalid characters.*"
+    )
     fun shouldReturnErrorWhenFilenameContainsInvalidChars() {
         uploadClient.uploadFile(testFile, metadataInvalidFilename)
     }

--- a/tests/integration/kotlin/src/test/kotlin/tus/DexTusClient.kt
+++ b/tests/integration/kotlin/src/test/kotlin/tus/DexTusClient.kt
@@ -1,0 +1,13 @@
+package tus
+
+import io.tus.java.client.TusClient
+import java.net.HttpURLConnection
+
+class DexTusClient : TusClient() {
+    lateinit var connection: HttpURLConnection
+
+    override fun prepareConnection(connection: HttpURLConnection) {
+        super.prepareConnection(connection)
+        this.connection = connection
+    }
+}

--- a/tests/integration/kotlin/src/test/resources/dev/aims-celr-csv.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/aims-celr-csv.xml
@@ -13,6 +13,9 @@
     </test>
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/aims-celr-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/aims-celr-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="aims-celr-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/daart-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/daart-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="daart-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/dex-hl7-hl7ingress.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/dex-hl7-hl7ingress.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dex-hl7-hl7ingress" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/dextesting-testevent1.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/dextesting-testevent1.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dextesting-testevent1" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dextesting-testevent1.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-aplhistoricaldata.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-aplhistoricaldata.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-aplhistoricaldata" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-covidallmonthlyvaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidallmonthlyvaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-covidbridgevaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-covidbridgevaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidbridgevaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-influenzavaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-influenzavaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-influenzavaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-routineimmunization.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-routineimmunization.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-routineimmunization" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/ndlp-rsvprevention.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/ndlp-rsvprevention.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-rsvprevention" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/dev/pulsenet-localsequencefile.xml
+++ b/tests/integration/kotlin/src/test/resources/dev/pulsenet-localsequencefile.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="pulsenet-localsequencefile" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/aims-celr-csv.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/aims-celr-csv.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="aims-celr-csv" />
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="FileCopy">
                 <methods>

--- a/tests/integration/kotlin/src/test/resources/prd/aims-celr-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/aims-celr-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="aims-celr-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/daart-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/daart-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="daart-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/dex-hl7-hl7ingress.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/dex-hl7-hl7ingress.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dex-hl7-hl7ingress" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/dextesting-testevent1.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/dextesting-testevent1.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dextesting-testevent1" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dextesting-testevent1.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-aplhistoricaldata.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-aplhistoricaldata.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-aplhistoricaldata" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-covidallmonthlyvaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidallmonthlyvaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-covidbridgevaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-covidbridgevaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidbridgevaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-influenzavaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-influenzavaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-influenzavaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-routineimmunization.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-routineimmunization.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-routineimmunization" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/ndlp-rsvprevention.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/ndlp-rsvprevention.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-rsvprevention" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/prd/pulsenet-localsequencefile.xml
+++ b/tests/integration/kotlin/src/test/resources/prd/pulsenet-localsequencefile.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="pulsenet-localsequencefile" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=aims-celr
+meta_ext_event=csv

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=csv

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-csv/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=aims-celr

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=aims-celr
+meta_ext_event=hl7

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=hl7

--- a/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/aims-celr-hl7/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=aims-celr

--- a/tests/integration/kotlin/src/test/resources/properties/daart-hl7/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/daart-hl7/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=daart
+meta_ext_event=hl7

--- a/tests/integration/kotlin/src/test/resources/properties/daart-hl7/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/daart-hl7/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=hl7

--- a/tests/integration/kotlin/src/test/resources/properties/daart-hl7/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/daart-hl7/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=daart

--- a/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=dex-hl7
+meta_ext_event=hl7ingress

--- a/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=hl7ingress

--- a/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dex-hl7-hl7ingress/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=dex-hl7

--- a/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=dextesting
+meta_ext_event=testevent1

--- a/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=testevent1

--- a/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/dextesting-testevent1/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=dextesting

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=aplhistoricaldata

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=aplhistoricaldata

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-aplhistoricaldata/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=covidallmonthlyvaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=covidallmonthlyvaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidallmonthlyvaccination/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=covidbridgevaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=covidbridgevaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-covidbridgevaccination/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=influenzavaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=influenzavaccination

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-influenzavaccination/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=routineimmunization

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=routineimmunization

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-routineimmunization/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=ndlp
+meta_ext_event=rsvprevention

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=rsvprevention

--- a/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/ndlp-rsvprevention/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=ndlp

--- a/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/invalid-filename.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/invalid-filename.properties
@@ -1,0 +1,3 @@
+filename=1<0>K:B"-/t\\e|s?t*-file
+meta_destination_id=pulsenet
+meta_ext_event=localsequencefile

--- a/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/no-dest-id.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/no-dest-id.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_ext_event=localsequencefile

--- a/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/no-event.properties
+++ b/tests/integration/kotlin/src/test/resources/properties/pulsenet-localsequencefile/no-event.properties
@@ -1,0 +1,2 @@
+filename=10KB-test-file
+meta_destination_id=pulsenet

--- a/tests/integration/kotlin/src/test/resources/stg/aims-celr-csv.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/aims-celr-csv.xml
@@ -13,6 +13,9 @@
     </test>
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/aims-celr-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/aims-celr-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="aims-celr-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/daart-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/daart-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="daart-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/dex-hl7-hl7ingress.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/dex-hl7-hl7ingress.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dex-hl7-hl7ingress" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/dextesting-testevent1.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/dextesting-testevent1.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dextesting-testevent1" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dextesting-testevent1.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-aplhistoricaldata.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-aplhistoricaldata.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-aplhistoricaldata" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-covidallmonthlyvaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidallmonthlyvaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-covidbridgevaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-covidbridgevaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidbridgevaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-influenzavaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-influenzavaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-influenzavaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-routineimmunization.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-routineimmunization.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-routineimmunization" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/ndlp-rsvprevention.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/ndlp-rsvprevention.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-rsvprevention" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/stg/pulsenet-localsequencefile.xml
+++ b/tests/integration/kotlin/src/test/resources/stg/pulsenet-localsequencefile.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="pulsenet-localsequencefile" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/aims-celr-csv.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/aims-celr-csv.xml
@@ -13,6 +13,9 @@
     </test>
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/aims-celr-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/aims-celr-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="aims-celr-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/daart-hl7.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/daart-hl7.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="daart-hl7" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/dex-hl7-hl7ingress.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/dex-hl7-hl7ingress.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dex-hl7-hl7ingress" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/dextesting-testevent1.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/dextesting-testevent1.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="dextesting-testevent1" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="dextesting-testevent1.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-aplhistoricaldata.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-aplhistoricaldata.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-aplhistoricaldata" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-covidallmonthlyvaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidallmonthlyvaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-covidbridgevaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-covidbridgevaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-covidbridgevaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-influenzavaccination.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-influenzavaccination.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-influenzavaccination" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-routineimmunization.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-routineimmunization.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-routineimmunization" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/ndlp-rsvprevention.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/ndlp-rsvprevention.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="ndlp-rsvprevention" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>

--- a/tests/integration/kotlin/src/test/resources/tst/pulsenet-localsequencefile.xml
+++ b/tests/integration/kotlin/src/test/resources/tst/pulsenet-localsequencefile.xml
@@ -3,6 +3,9 @@
     <parameter name="USE_CASE" value="pulsenet-localsequencefile" />
     <test name="Metadata Verify">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
+        <parameter name="SENDER_MANIFEST_NO_DEST_ID" value="no-dest-id.properties" />
+        <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
+        <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
             <class name="MetadataVerify" />
         </classes>


### PR DESCRIPTION
Added a new test in `MetadataVerify.kt` for invalid filename characters.
Also added usecase specific properties files for non-happy path metadata verify tests.