### PR TITLE
UPLOAD-1149 pulsenet v2 sender manifest config

### DIFF
--- a/upload-configs/v2/pulsenet-other.json
+++ b/upload-configs/v2/pulsenet-other.json
@@ -5,16 +5,19 @@
          {
             "field_name": "sender_id",
             "required": true,
+            "allowed_values": ["LAB-TEST"],
             "description": "This field is the identifier for the sender of the data."
          },
          {
             "field_name": "data_producer_id",
             "required": true,
+            "allowed_values": ["DC-TEST"],
             "description": "This field is the identifier for the data producer."
          },
          {
             "field_name": "jurisdiction",
             "required": true,
+            "allowed_values": ["DC"],
             "description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null."
          },
          {
@@ -26,12 +29,14 @@
          {
             "field_name": "data_stream_id",
             "required": true,
+            "allowed_values": ["pulsenet"],
             "description": "This field is the identifier for the data stream.",
             "compat_field_name": "meta_destination_id"
          },
          {
             "field_name": "data_stream_route",
             "required": true,
+            "allowed_values": ["other"],
             "description": "This recieved is the route of the data stream.",
             "compat_field_name": "meta_ext_event"
          }
@@ -41,7 +46,7 @@
       "filename_suffix": "clock_ticks",
       "folder_structure": "date_YYYY_MM_DD",
       "targets": [
-         "edav"
+         "routing"
       ]
    }
 }


### PR DESCRIPTION
Updates to the pulsenet v2 sender manifest config

- name change to pulsenet-other.json to align with data stream route nomenclature
- dummy value added to sender id allowed values
- dummy value added to data producer id allowed values
- one state value added to jurisdiction allowed values
- `pulsenet` value added to data stream allowed values
- `other` value added to data stream route allowed values
- copy config target updated to `routing`