### PR TITLE
UPLOAD-1186 Translate post-receive hook to go

### DIFF
--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -89,14 +89,14 @@ func postReceiveHook(event handler.HookEvent) (hooks.HookResponse, error) {
 	uploadId := event.Upload.ID
 	uploadSize := event.Upload.Size
 	uploadOffset := event.Upload.Offset
-	manifest := event.Upload.MetaData
+	uploadMetadata := event.Upload.MetaData
 
 	logger.Info(
 		"[PostReceive]: event.Upload values",
-		" manifest: ", manifest,
-		" uploadId: ", uploadId,
-		" uploadSize: ", uploadSize,
-		" uploadOffset: ", uploadOffset,
+		"uploadMetadata", uploadMetadata,
+		"uploadId", uploadId,
+		"uploadSize", uploadSize,
+		"uploadOffset", uploadOffset,
 	)
 
 	// filePath := fmt.Sprintf("/tmp/testing1111.txt")
@@ -134,10 +134,10 @@ func postReceiveHook(event handler.HookEvent) (hooks.HookResponse, error) {
 
 		logger.Info("[post-receive]: Upload information.",
 			"uploadOffset", uploadOffset,
-			", latestOffset =", latestOffsetStr,
-			", nowEpoch =", nowEpoch,
-			", lastModifiedEpoch =", lastModifiedEpoch,
-			", elapsedSec =", elapsedSeconds)
+			"latestOffset", latestOffsetStr,
+			"nowEpoch", nowEpoch,
+			"lastModifiedEpoch", lastModifiedEpoch,
+			"elapsedSec", elapsedSeconds)
 	}
 
 	// Conditional Update Logic
@@ -162,8 +162,8 @@ func postReceiveHook(event handler.HookEvent) (hooks.HookResponse, error) {
 		// TODO: Replace post-receive-bin.py Python with Go HERE
 		//     ./post-receive-bin --id $id --offset $offset --size $size --metadata "$metadata"
 		// create processPostReceive function
-		//		- get metadata/manifest from event.Upload.MetaData
-		//		- get filename from metadata/manifest
+		//		- get metadata from event.Upload.MetaData
+		//		- get filename from metadata
 		//		- create JSON message
 		//		- send JSON message
 		// 		- Load Service Bus connection details from environment or config

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -79,6 +79,12 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		},
 	}
 
+	postReceiveHook := metadata.SenderManifestVerification{
+		Loader: &FileConfigLoader{
+			FileSystem: os.DirFS(appConfig.UploadConfigPath),
+		},
+	}
+
 	if appConfig.DexAzUploadConfig != nil {
 		client, err := storeaz.NewBlobClient(*appConfig.DexAzUploadConfig)
 		if err != nil {
@@ -91,5 +97,6 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 	}
 
 	handler.Register(tusHooks.HookPreCreate, preCreateHook.Verify)
+	handler.Register(tusHooks.HookPostReceive, postReceiveHook.PostReceive)
 	return handler, nil
 }

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/validation"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/storeaz"
 	prebuilthooks "github.com/cdcgov/data-exchange-upload/upload-server/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/handler"
@@ -79,12 +78,13 @@ func (l *AzureConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte
 //
 //	       like preCreate?
 //		      Is currently a duplicate for  metadata.SenderManifestVerification
-type HookConfigLoader struct {
-	Loader validation.ConfigLoader
-}
+//type HookConfigLoader struct {
+//	Loader validation.ConfigLoader
+//}
 
 // TODO: Relocate in to maybe internal/hooks or internal/upload-status ?
-func (v *HookConfigLoader) PostReceive(event handler.HookEvent) (hooks.HookResponse, error) {
+// func (v *HookConfigLoader) PostReceive(event handler.HookEvent) (hooks.HookResponse, error) {
+func postReceive(event handler.HookEvent) (hooks.HookResponse, error) {
 	resp := hooks.HookResponse{}
 
 	// Get values from event
@@ -185,11 +185,11 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		},
 	}
 
-	postReceiveHook := HookConfigLoader{
-		Loader: &FileConfigLoader{
-			FileSystem: os.DirFS(appConfig.UploadConfigPath),
-		},
-	}
+	//postReceiveHook := HookConfigLoader{
+	//	Loader: &FileConfigLoader{
+	//		FileSystem: os.DirFS(appConfig.UploadConfigPath),
+	//	},
+	//}
 
 	if appConfig.DexAzUploadConfig != nil {
 		client, err := storeaz.NewBlobClient(*appConfig.DexAzUploadConfig)
@@ -203,6 +203,6 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 	}
 
 	handler.Register(tusHooks.HookPreCreate, preCreateHook.Verify)
-	handler.Register(tusHooks.HookPostReceive, postReceiveHook.PostReceive)
+	handler.Register(tusHooks.HookPostReceive, postReceive)
 	return handler, nil
 }

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -168,6 +168,15 @@ func postReceive(event handler.HookEvent) (hooks.HookResponse, error) {
 
 		// TODO: Replace post-receive-bin.py Python with Go HERE
 		//     ./post-receive-bin --id $id --offset $offset --size $size --metadata "$metadata"
+		// create processPostReceive function
+		//		- get metadata/manifest from event.Upload.MetaData
+		//		- get filename from metadata/manifest
+		//		- create JSON message
+		//		- send JSON message
+		// 		- Load Service Bus connection details from environment or config
+		// 			connectionString := os.Getenv("SERVICE_BUS_CONNECTION_STRING")
+		// 			queueName := os.Getenv("QUEUE_NAME")
+
 	} else {
 		logger.Info("[post-receive]: Skipping update")
 	}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -132,29 +132,3 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 
 	return resp, nil
 }
-
-// TODO: Relocate in to maybe internal/hooks or internal/upload-status ?
-func (v *SenderManifestVerification) PostReceive(event handler.HookEvent) (hooks.HookResponse, error) {
-	resp := hooks.HookResponse{}
-
-	// Get values from event
-	uploadId := event.Upload.ID
-	uploadSize := event.Upload.Size
-	uploadOffset := event.Upload.Offset
-	manifest := event.Upload.MetaData
-
-	logger.Info(
-		"[PostReceive]: event.Upload values",
-		" manifest: ", manifest,
-		" uploadId: ", uploadId,
-		" uploadSize: ", uploadSize,
-		" uploadOffset: ", uploadOffset,
-	)
-
-	// TODO: Add shell script logic here.
-
-	// TODO: Covert Python post_receive_bin.py starting here...
-
-	return resp, nil
-
-}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -86,6 +86,7 @@ func getVersionFromManifest(ctx context.Context, manifest handler.MetaData, load
 	return loadConfig(ctx, configLoc.Path(), loader)
 }
 
+// TODO: Rename to something like: HookConfigLoader
 type SenderManifestVerification struct {
 	Loader validation.ConfigLoader
 }
@@ -130,4 +131,30 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 	}
 
 	return resp, nil
+}
+
+// TODO: Relocate in to maybe internal/hooks or internal/upload-status ?
+func (v *SenderManifestVerification) PostReceive(event handler.HookEvent) (hooks.HookResponse, error) {
+	resp := hooks.HookResponse{}
+
+	// Get values from event
+	uploadId := event.Upload.ID
+	uploadSize := event.Upload.Size
+	uploadOffset := event.Upload.Offset
+	manifest := event.Upload.MetaData
+
+	logger.Info(
+		"[PostReceive]: event.Upload values",
+		" manifest: ", manifest,
+		" uploadId: ", uploadId,
+		" uploadSize: ", uploadSize,
+		" uploadOffset: ", uploadOffset,
+	)
+
+	// TODO: Add shell script logic here.
+
+	// TODO: Covert Python post_receive_bin.py starting here...
+
+	return resp, nil
+
 }

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -86,7 +86,6 @@ func getVersionFromManifest(ctx context.Context, manifest handler.MetaData, load
 	return loadConfig(ctx, configLoc.Path(), loader)
 }
 
-// TODO: Rename to something like: HookConfigLoader
 type SenderManifestVerification struct {
 	Loader validation.ConfigLoader
 }


### PR DESCRIPTION
Translate the [post-receive hook](https://github.com/CDCgov/data-exchange-upload/blob/main/tus/file-hooks/upload-status/post_receive_bin.py) that submits data to PS API into go and include it in the Upload Go binary.

CURRENT STATUS:

- Added and registered postReceive() as a tusd plugin type hook function.

-  This is testing OK with the server running via:
```
go run ./cmd/main.go -appconf=./configs/local/local.env
```
- Remove of HookConfigLoader, since the config isn't used for this hook.
- Created initial shell script code in Go.
- NEXT:  Will be adding migrated python code logic next.
