### PR TITLE
UPLOAD-1242 v1 config target fix influenza vaccination

### DIFF
--- a/upload-configs/v1/ndlp-influenzaVaccination.json
+++ b/upload-configs/v1/ndlp-influenzaVaccination.json
@@ -50,7 +50,7 @@
 		"filename_suffix": "clock_ticks",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
-			"routing"
+			"edav"
 		]
 	}
 }


### PR DESCRIPTION
Update to v1 upload config for influenza vaccination to fix the target to edav instead of routing