### PR TITLE
upload-1185: add post-create hook in golang

### DIFF
--- a/tus/file-hooks/post-create/post_create_bin.py
+++ b/tus/file-hooks/post-create/post_create_bin.py
@@ -42,6 +42,7 @@ def get_feature_flag(flag_name):
 processing_status_reports_enabled = get_feature_flag("PROCESSING_STATUS_REPORTS")
 processing_status_traces_enabled = get_feature_flag("PROCESSING_STATUS_TRACES")
 
+
 def get_required_metadata(metadata_json_dict):
     metadata_version = metadata_json_dict.get('version', METADATA_VERSION_ONE)
     
@@ -59,6 +60,7 @@ def get_required_metadata(metadata_json_dict):
 
     return [metadata_json_dict[field] for field in required_fields]
 
+
 def get_filename_from_metadata(metadata_json_dict):
     filename_metadata_fields = ['filename', 'original_filename', 'meta_ext_filename']
 
@@ -70,6 +72,7 @@ def get_filename_from_metadata(metadata_json_dict):
             break
 
     return filename
+
 
 def post_create(use_case, use_case_category, metadata_json_dict, tguid):
     logger.info(f'Creating trace for upload {tguid} with use case {use_case} and use case category {use_case_category}')
@@ -88,8 +91,8 @@ def post_create(use_case, use_case_category, metadata_json_dict, tguid):
     else:
         logger.debug("Trace creation is disabled by feature flag.")
 
-def create_metadata_verification_span(ps_api_controller, trace_id, parent_span_id, use_case, use_case_category, metadata_json_dict, tguid):
 
+def create_metadata_verification_span(ps_api_controller, trace_id, parent_span_id, use_case, use_case_category, metadata_json_dict, tguid):
     try:
         # Start the upload stage metadata verification span
         if processing_status_traces_enabled:
@@ -106,8 +109,8 @@ def create_metadata_verification_span(ps_api_controller, trace_id, parent_span_i
     except Exception as e:
         logger.error(f"An exception occurred during creation of metadata verification span: {e}")
 
-def create_metadata_verification_report_json(ps_api_controller, metadata_json_dict, tguid, use_case, use_case_category):
 
+def create_metadata_verification_report_json(ps_api_controller, metadata_json_dict, tguid, use_case, use_case_category):
     try:
         json_payload = { 
             "schema_version": "0.0.1",
@@ -123,6 +126,7 @@ def create_metadata_verification_report_json(ps_api_controller, metadata_json_di
     except Exception as e:
         logger.error(f"An exception occurred uploading metadata verification report json: {e}")
         raise Exception(f"Unable to upload report json.")
+
 
 def main(argv):
     

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -70,6 +70,107 @@ func (l *AzureConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte
 	return io.ReadAll(downloadResponse.Body)
 }
 
+func getFeatureFlag(client appconfigurationapi.BaseClientAPI, flagName string) (bool, error) {
+	flag, err := client.GetConfigurationSetting(nil, ".appconfig.featureflag/"+flagName, "")
+	if err != nil {
+		return false, fmt.Errorf("Error fetching feature flag %s: %v", flagName, err)
+	}
+	return *flag.Value.Value, nil
+}
+
+func getRequiredMetadata(metadata map[string]interface{}) ([]interface{}, error) {
+	metadataVersion := metadata["version"].(string)
+
+	var requiredFields []string
+		switch metadataVersion {
+		case METADATA_VERSION_ONE:
+			requiredFields = REQUIRED_VERSION_ONE_FIELDS
+		case METADATA_VERSION_TWO:
+			requiredFields = REQUIRED_VERSION_TWO_FIELDS
+		default:
+			return nil, fmt.Errorf("Unsupported metadata version: %s", metadataVersion)
+	}
+
+	var missingMetadataFields []interface{}
+	for _, field := range requiredFields {
+		if _, ok := metadata[field]; !ok {
+			missingMetadataFields = append(missingMetadataFields, field)
+		}
+	}
+
+	if len(missingMetadataFields) > 0 {
+		return nil, fmt.Errorf("Missing one or more required metadata fields: %v", missingMetadataFields)
+	}
+
+	var values []interface{}
+	for _, field := range requiredFields {
+		values = append(values, metadata[field])
+	}
+	return values, nil
+}
+
+func getFilenameFromMetadata(metadata map[string]interface{}) string {
+	filenameMetadataFields := []string{"filename", "original_filename", "meta_ext_filename"}
+
+	var filename string
+	for _, field := range filenameMetadataFields {
+		if val, ok := metadata[field]; ok {
+			filename = val.(string)
+			break
+		}
+	}
+
+	return filename
+}
+
+func postCreate(useCase, useCaseCategory string, metadata map[string]interface{}, tguid string) {
+	logger.Printf("Creating trace for upload %s with use case %s and use case category %s\n", tguid, useCase, useCaseCategory)
+
+	psAPIController := NewProcStatController(os.Getenv("PS_API_URL"))
+
+	if processingStatusTracesEnabled {
+		traceID, parentSpanID := psAPIController.CreateUploadTrace(tguid, useCase, useCaseCategory)
+		logger.Printf("Created trace for upload %s with trace ID %s and parent span ID %s\n", tguid, traceID, parentSpanID)
+
+		createMetadataVerificationSpan(psAPIController, traceID, parentSpanID, useCase, useCaseCategory, metadata, tguid)
+
+		// Start the upload child span. Will be stopped in post-finish hook when the upload is complete.
+		psAPIController.StartSpanForTrace(traceID, parentSpanID, "dex-upload")
+		logger.Printf("Created child span for parent span %s with stage name of dex-upload\n", parentSpanID)
+	} else {
+		logger.Printf("Trace creation is disabled by feature flag.\n")
+	}
+}
+
+func createMetadataVerificationSpan(psAPIController *ProcStatController, traceID, parentSpanID, useCase, useCaseCategory string, metadata map[string]interface{}, tguid string) {
+	if processingStatusTracesEnabled {
+		_, metadataVerifySpanID := psAPIController.StartSpanForTrace(traceID, parentSpanID, "metadata-verify")
+		logger.Printf("Started child span %s with stage name metadata-verify of parent span %s\n", metadataVerifySpanID, parentSpanID)
+	}
+
+	if processingStatusReportsEnabled {
+		createMetadataVerificationReportJSON(psAPIController, metadata, tguid, useCase, useCaseCategory)
+	}
+
+	if processingStatusTracesEnabled {
+		psAPIController.StopSpanForTrace(traceID, metadataVerifySpanID)
+		logger.Printf("Stopped child span %s with stage name metadata-verify of parent span %s\n", metadataVerifySpanID, parentSpanID)
+	}
+}
+
+func createMetadataVerificationReportJSON(psAPIController *ProcStatController, metadata map[string]interface{}, tguid, useCase, useCaseCategory string) {
+	jsonPayload := map[string]interface{}{
+		"schema_version": "0.0.1",
+		"schema_name":    STAGE_NAME,
+		"filename":       getFilenameFromMetadata(metadata),
+		"timestamp":      time.Now().Format(time.RFC3339),
+		"metadata":       metadata,
+		"issues":         []interface{}{},
+	}
+
+	psAPIController.CreateReportJSON(tguid, useCase, useCaseCategory, STAGE_NAME, jsonPayload)
+}
+
 func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) {
 	handler := &prebuilthooks.PrebuiltHook{}
 
@@ -90,6 +191,26 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		}
 	}
 
+	postCreateHook := HookHandlerFunc(func(e handler.HookEvent) (handler.HTTPResponse, handler.FileInfoChanges, error) {
+		if e.Type == tusHooks.HookPreCreate {
+			metadataJSON := map[string]interface{}{}
+			err := json.Unmarshal(e.Upload.Metadata, &metadataJSON)
+			if err != nil {
+				return handler.HTTPResponse{}, nil, err
+			}
+
+			useCaseValues, err := getRequiredMetadata(metadataJSON)
+			if err != nil {
+				return handler.HTTPResponse{}, nil, err
+			}
+
+			postCreate(useCaseValues[0].(string), useCaseValues[1].(string), metadataJSON, e.Upload.ID)
+		}
+
+		return handler.HTTPResponse{}, nil, nil
+	})
+
 	handler.Register(tusHooks.HookPreCreate, preCreateHook.Verify)
+	handler.Register(tusHooks.HookPostCreate, postCreateHook.Verify)
 	return handler, nil
 }

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -74,7 +74,7 @@ func getRequiredMetadata(metadata map[string]interface{}) ([]interface{}, error)
 	metadataVersion := metadata["version"].(string)
 
 	var requiredFields []string
-		switch metadataVersion {
+	switch metadataVersion {
 		case METADATA_VERSION_ONE:
 			requiredFields = REQUIRED_VERSION_ONE_FIELDS
 		case METADATA_VERSION_TWO:
@@ -155,21 +155,15 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 
 	postCreateHook := HookHandlerFunc(func(e handler.HookEvent) (handler.HTTPResponse, handler.FileInfoChanges, error) {
 		if e.Type == tusHooks.HookPreCreate {
-			metadataJSON := map[string]interface{}{}
-			err := json.Unmarshal(e.Upload.Metadata, &metadataJSON)
+			useCase := metadata.Version 
+			useCaseCategory := metadata.Category 
+
+			useCaseValues, err := getRequiredMetadata(metadata)
 			if err != nil {
-				return handler.HTTPResponse{}, nil, err
+				return handler.HTTPResponse{}, nil, err 
 			}
 
-			useCaseValues, err := getRequiredMetadata(metadataJSON)
-			if err != nil {
-				return handler.HTTPResponse{}, nil, err
-			}
-
-			postCreate(useCaseValues[0].(string), useCaseValues[1].(string), metadataJSON, e.Upload.ID)
-		}
-
-		return handler.HTTPResponse{}, nil, nil
+			postCreate(useCase, useCaseCategory, metadata, e.Upload.ID)
 	})
 
 	handler.Register(tusHooks.HookPreCreate, preCreateHook.Verify)

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -70,14 +70,6 @@ func (l *AzureConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte
 	return io.ReadAll(downloadResponse.Body)
 }
 
-func getFeatureFlag(client appconfigurationapi.BaseClientAPI, flagName string) (bool, error) {
-	flag, err := client.GetConfigurationSetting(nil, ".appconfig.featureflag/"+flagName, "")
-	if err != nil {
-		return false, fmt.Errorf("Error fetching feature flag %s: %v", flagName, err)
-	}
-	return *flag.Value.Value, nil
-}
-
 func getRequiredMetadata(metadata map[string]interface{}) ([]interface{}, error) {
 	metadataVersion := metadata["version"].(string)
 


### PR DESCRIPTION
- Metadata verification report can be sent to PS API
- Trace functionality is assessed and decided if it should remain or not
- Should fail elegantly without disrupting the upload

link: https://cdc-dexops.atlassian.net/browse/UPLOAD-1185