### PR TITLE
UPLOAD-1258/global-timestamp

### DIFF
--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/storeaz"
 	prebuilthooks "github.com/cdcgov/data-exchange-upload/upload-server/pkg/hooks"
-	"github.com/tus/tusd/v2/pkg/handler"
 	tusHooks "github.com/tus/tusd/v2/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/hooks/file"
 )
@@ -26,15 +25,6 @@ func GetHookHandler(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error)
 		}, nil
 	}
 	return PrebuiltHooks(appConfig)
-}
-
-func HookHandlerFunc(f func(handler.HookEvent) (handler.HTTPResponse, handler.FileInfoChanges, error)) func(handler.HookEvent) (tusHooks.HookResponse, error) {
-	return func(e handler.HookEvent) (res tusHooks.HookResponse, err error) {
-		resp, changes, err := f(e)
-		res.HTTPResponse = resp
-		res.ChangeFileInfo = changes
-		return res, err
-	}
 }
 
 type FileConfigLoader struct {

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -80,6 +80,6 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		}
 	}
 
-	handler.Register(tusHooks.HookPreCreate, metadata.WithTimestamp(preCreateHook.Verify))
+	handler.Register(tusHooks.HookPreCreate, metadata.WithTimestamp, preCreateHook.Verify)
 	return handler, nil
 }

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -90,6 +90,6 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		}
 	}
 
-	handler.Register(tusHooks.HookPreCreate, preCreateHook.Verify)
+	handler.Register(tusHooks.HookPreCreate, metadata.WithTimestamp(preCreateHook.Verify))
 	return handler, nil
 }

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -134,15 +134,13 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 	return resp, nil
 }
 
-// type HandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
-
 func WithTimestamp(next prebuilthooks.HookHandlerFunc) prebuilthooks.HookHandlerFunc {
 	return func(event handler.HookEvent) (hooks.HookResponse, error) {
 		timestamp := time.Now().Format(time.RFC3339)
 		logger.Info("adding global timestamp", "timestamp", timestamp)
 
 		manifest := event.Upload.MetaData
-		manifest["global_timestamp"] = timestamp
+		manifest["dex_ingest_datetime"] = timestamp
 
 		// Tell tus to update the file metadata with the hydrated manifest.
 		resp := hooks.HookResponse{}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/v1"
 	v2 "github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/v2"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/validation"
-	prebuilthooks "github.com/cdcgov/data-exchange-upload/upload-server/pkg/hooks"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/sloger"
 	"github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
@@ -92,9 +91,7 @@ type SenderManifestVerification struct {
 	Loader validation.ConfigLoader
 }
 
-func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.HookResponse, error) {
-	resp := hooks.HookResponse{}
-
+func (v *SenderManifestVerification) Verify(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
 	manifest := event.Upload.MetaData
 	logger.Info("checking the sender manifest:", "manifest", manifest)
 
@@ -134,14 +131,12 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 	return resp, nil
 }
 
-func WithTimestamp(next prebuilthooks.HookHandlerFunc) prebuilthooks.HookHandlerFunc {
-	return func(event handler.HookEvent) (hooks.HookResponse, error) {
-		timestamp := time.Now().Format(time.RFC3339)
-		logger.Info("adding global timestamp", "timestamp", timestamp)
+func WithTimestamp(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
+	timestamp := time.Now().Format(time.RFC3339)
+	logger.Info("adding global timestamp", "timestamp", timestamp)
 
-		manifest := event.Upload.MetaData
-		manifest["dex_ingest_datetime"] = timestamp
+	manifest := event.Upload.MetaData
+	manifest["dex_ingest_datetime"] = timestamp
 
-		return next(event)
-	}
+	return resp, nil
 }

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -136,7 +136,13 @@ func WithTimestamp(event handler.HookEvent, resp hooks.HookResponse) (hooks.Hook
 	logger.Info("adding global timestamp", "timestamp", timestamp)
 
 	manifest := event.Upload.MetaData
+
+	if resp.ChangeFileInfo.MetaData != nil {
+		manifest = resp.ChangeFileInfo.MetaData
+	}
+
 	manifest["dex_ingest_datetime"] = timestamp
+	resp.ChangeFileInfo.MetaData = manifest
 
 	return resp, nil
 }

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -131,3 +131,12 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 
 	return resp, nil
 }
+
+type HandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
+
+func WithTimestamp(next HandlerFunc) HandlerFunc {
+	return func(event handler.HookEvent) (hooks.HookResponse, error) {
+		logger.Info("adding global timestamp...")
+		return next(event)
+	}
+}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -142,10 +142,6 @@ func WithTimestamp(next prebuilthooks.HookHandlerFunc) prebuilthooks.HookHandler
 		manifest := event.Upload.MetaData
 		manifest["dex_ingest_datetime"] = timestamp
 
-		// Tell tus to update the file metadata with the hydrated manifest.
-		resp := hooks.HookResponse{}
-		resp.ChangeFileInfo.MetaData = manifest
-
 		return next(event)
 	}
 }

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -16,6 +16,7 @@ import (
 	v1 "github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/v1"
 	v2 "github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/v2"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/validation"
+	prebuilthooks "github.com/cdcgov/data-exchange-upload/upload-server/pkg/hooks"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/sloger"
 	"github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
@@ -133,9 +134,9 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent) (hooks.Hook
 	return resp, nil
 }
 
-type HandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
+// type HandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
 
-func WithTimestamp(next HandlerFunc) HandlerFunc {
+func WithTimestamp(next prebuilthooks.HookHandlerFunc) prebuilthooks.HookHandlerFunc {
 	return func(event handler.HookEvent) (hooks.HookResponse, error) {
 		timestamp := time.Now().Format(time.RFC3339)
 		logger.Info("adding global timestamp", "timestamp", timestamp)

--- a/upload-server/pkg/hooks/prebuilt.go
+++ b/upload-server/pkg/hooks/prebuilt.go
@@ -2,12 +2,15 @@ package hooks
 
 import (
 	"github.com/tus/tusd/v2/pkg/handler"
+	"github.com/tus/tusd/v2/pkg/hooks"
 	tusHooks "github.com/tus/tusd/v2/pkg/hooks"
 )
 
 type PrebuiltHook struct {
-	hookMapping map[tusHooks.HookType]func(handler.HookEvent) (tusHooks.HookResponse, error)
+	hookMapping map[tusHooks.HookType]HookHandlerFunc
 }
+
+type HookHandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
 
 func (ph *PrebuiltHook) Setup() error {
 	return nil
@@ -22,9 +25,9 @@ func (ph *PrebuiltHook) InvokeHook(req tusHooks.HookRequest) (res tusHooks.HookR
 	return hook(req.Event)
 }
 
-func (ph *PrebuiltHook) Register(t tusHooks.HookType, hook func(handler.HookEvent) (tusHooks.HookResponse, error)) {
+func (ph *PrebuiltHook) Register(t tusHooks.HookType, hook HookHandlerFunc) {
 	if ph.hookMapping == nil {
-		ph.hookMapping = map[tusHooks.HookType]func(handler.HookEvent) (tusHooks.HookResponse, error){}
+		ph.hookMapping = map[tusHooks.HookType]HookHandlerFunc{}
 	}
 	ph.hookMapping[t] = hook
 }

--- a/upload-server/pkg/hooks/prebuilt.go
+++ b/upload-server/pkg/hooks/prebuilt.go
@@ -2,7 +2,6 @@ package hooks
 
 import (
 	"github.com/tus/tusd/v2/pkg/handler"
-	"github.com/tus/tusd/v2/pkg/hooks"
 	tusHooks "github.com/tus/tusd/v2/pkg/hooks"
 )
 
@@ -10,7 +9,7 @@ type PrebuiltHook struct {
 	hookMapping map[tusHooks.HookType]HookHandlerFunc
 }
 
-type HookHandlerFunc func(event handler.HookEvent) (hooks.HookResponse, error)
+type HookHandlerFunc func(event handler.HookEvent) (tusHooks.HookResponse, error)
 
 func (ph *PrebuiltHook) Setup() error {
 	return nil

--- a/upload-server/pkg/hooks/prebuilt.go
+++ b/upload-server/pkg/hooks/prebuilt.go
@@ -6,27 +6,42 @@ import (
 )
 
 type PrebuiltHook struct {
-	hookMapping map[tusHooks.HookType]HookHandlerFunc
+	hookMapping map[tusHooks.HookType][]HookHandlerFunc
 }
 
-type HookHandlerFunc func(event handler.HookEvent) (tusHooks.HookResponse, error)
+type HookHandlerFunc func(event handler.HookEvent, resp tusHooks.HookResponse) (tusHooks.HookResponse, error)
 
 func (ph *PrebuiltHook) Setup() error {
 	return nil
 }
 
 func (ph *PrebuiltHook) InvokeHook(req tusHooks.HookRequest) (res tusHooks.HookResponse, err error) {
-	hook, ok := ph.hookMapping[req.Type]
+	hookFuncs, ok := ph.hookMapping[req.Type]
 	if !ok {
 		// nothing registered
 		return res, nil
 	}
-	return hook(req.Event)
+
+	resp := tusHooks.HookResponse{}
+	for _, hf := range hookFuncs {
+		resp, err = hf(req.Event, resp)
+		// Return early if we got an error.
+		if err != nil {
+			return resp, err
+		}
+
+		// Return early if a middleware function set a response.
+		if resp.HTTPResponse.StatusCode != 0 {
+			return resp, nil
+		}
+	}
+
+	return resp, nil
 }
 
-func (ph *PrebuiltHook) Register(t tusHooks.HookType, hook HookHandlerFunc) {
+func (ph *PrebuiltHook) Register(t tusHooks.HookType, hookFuncs ...HookHandlerFunc) {
 	if ph.hookMapping == nil {
-		ph.hookMapping = map[tusHooks.HookType]HookHandlerFunc{}
+		ph.hookMapping = map[tusHooks.HookType][]HookHandlerFunc{}
 	}
-	ph.hookMapping[t] = hook
+	ph.hookMapping[t] = hookFuncs
 }

--- a/upload-server/readme.md
+++ b/upload-server/readme.md
@@ -31,6 +31,12 @@ go test -coverprofile=c.out ./...
 go tool cover -html=c.out
 ```
 
+### Running locally with Azurite
+
+This method of running locally let's you simulate a connection to an Azure data store.  It uses a tool called Azurite, which simulates a storage account on your local machine.
+
+To get started, follow [these docs](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=npm%2Cblob-storage) to get Azurite installed and running.  Next, you'll need to set up the upload configs whithin the simulator's blob storage.  You can do this with the Azure CLI, but probably the easiest way to do this is with the Azure Storage Explorer.  Get this tool installed on your machine.  Once installed, sign in to your Azure -SU account and connect to Azurite.  Next, create a new blob container called `upload-configs`.  Finally, upload the `v1` and `v2` folders within the `upload-configs` directory of this repo to this container.
+
 ## Configuration
 
 Configuration of the `upload-server` is managed through environment variables. As a convenience these can also be set in a file
@@ -38,7 +44,7 @@ and passed as a flag :`go run ./cmd/main.go -appconf <path to conf file>` or `up
 
 By default the `upload-server` is set to run locally using the filesystem and an in memory lock mechanism, so for most local development it is sufficient rely on the defaults.
 
-An example set of environment variables that could be exported to connect to a locally running azurite (such as the one in the docker-compose.yml file)
+An example set of environment variables that could be exported to connect to a locally running azurite (such as the one in the docker-compose.yml file).  You can find Azurite's default storage account name and key here: [https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=npm%2Cblob-storage#well-known-storage-account-and-key](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=npm%2Cblob-storage#well-known-storage-account-and-key).
 
 ```
 # ./.env

--- a/upload-server/testing/testing.go
+++ b/upload-server/testing/testing.go
@@ -192,5 +192,11 @@ func RunTusTestCase(url string, testFile string, c testCase) error {
 		return fmt.Errorf("invalid info response: %s", infoJson)
 	}
 
+	// check hydrated manifest fields
+	_, ok = infoJson.Manifest["global_timestamp"]
+	if !ok {
+		return fmt.Errorf("invalid file manifest: %s", infoJson.Manifest)
+	}
+
 	return nil
 }

--- a/upload-server/testing/testing.go
+++ b/upload-server/testing/testing.go
@@ -193,7 +193,7 @@ func RunTusTestCase(url string, testFile string, c testCase) error {
 	}
 
 	// check hydrated manifest fields
-	_, ok = infoJson.Manifest["global_timestamp"]
+	_, ok = infoJson.Manifest["dex_ingest_datetime"]
 	if !ok {
 		return fmt.Errorf("invalid file manifest: %s", infoJson.Manifest)
 	}


### PR DESCRIPTION
This PR adds a global timestamp field to the sender manifest, which ultimately gets attached to the metadata of the file.  This global timestamp is generated when an upload is being initialized.  It will be used as a global time anchor for searching for uploads across a time range.  It is stored in ISO format in UTC.