### PR TITLE
Hotfix/file overwrite config

### DIFF
--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -2,8 +2,6 @@ import auth.AuthClient
 import com.azure.identity.ClientSecretCredentialBuilder
 import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
-import com.azure.storage.blob.models.BlobListDetails
-import com.azure.storage.blob.models.ListBlobsOptions
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import model.UploadConfig
@@ -14,8 +12,6 @@ import org.testng.TestNGException
 import org.testng.annotations.*
 import tus.UploadClient
 import util.*
-import java.time.Duration
-import kotlin.math.exp
 
 @Listeners(UploadIdTestListener::class)
 @Test()

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -1,8 +1,12 @@
 import auth.AuthClient
 import com.azure.identity.ClientSecretCredentialBuilder
+import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.models.BlobListDetails
 import com.azure.storage.blob.models.ListBlobsOptions
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import model.UploadConfig
 import org.joda.time.DateTime
 import org.testng.Assert
 import org.testng.ITestContext
@@ -11,6 +15,7 @@ import org.testng.annotations.*
 import tus.UploadClient
 import util.*
 import java.time.Duration
+import kotlin.math.exp
 
 @Listeners(UploadIdTestListener::class)
 @Test()
@@ -26,6 +31,8 @@ class FileCopy {
             .build())
     private val routingBlobClient = Azure.getBlobServiceClient(EnvConfig.ROUTING_STORAGE_CONNECTION_STRING)
     private lateinit var bulkUploadsContainerClient: BlobContainerClient
+    private lateinit var uploadConfigBlobClient: BlobClient
+    private lateinit var uploadConfig: UploadConfig
     private lateinit var edavContainerClient: BlobContainerClient
     private lateinit var routingContainerClient: BlobContainerClient
     private lateinit var uploadClient: UploadClient
@@ -48,6 +55,12 @@ class FileCopy {
         val metadata = Metadata.convertPropertiesToMetadataMap(propertiesFilePath)
 
         bulkUploadsContainerClient = dexBlobClient.getBlobContainerClient(Constants.BULK_UPLOAD_CONTAINER_NAME)
+
+        uploadConfigBlobClient = dexBlobClient
+            .getBlobContainerClient(Constants.UPLOAD_CONFIG_CONTAINER_NAME)
+            .getBlobClient("${USE_CASE}.json")
+        uploadConfig = ObjectMapper().readValue(uploadConfigBlobClient.downloadContent().toString())
+
         edavContainerClient = edavBlobClient.getBlobContainerClient(Constants.EDAV_UPLOAD_CONTAINER_NAME)
         routingContainerClient = routingBlobClient.getBlobContainerClient(Constants.ROUTING_UPLOAD_CONTAINER_NAME)
         uploadId = uploadClient.uploadFile(testFile, metadata) ?: throw TestNGException("Error uploading file ${testFile.name}")
@@ -74,20 +87,18 @@ class FileCopy {
     }
 
     @Test(groups = [Constants.Groups.FILE_COPY])
-    fun shouldCopyToEdavContainer() {
-        val expectedFilename = "${Metadata.getFilePrefixByDate(DateTime.now(), useCase)}/${testFile.nameWithoutExtension}_${uploadId}${testFile.extension}"
-        val edavUploadBlob = edavContainerClient.getBlobClient(expectedFilename)
+    fun shouldCopyToDestinationContainers() {
+        val filenameSuffix = if (uploadConfig.copyConfig.filenameSuffix == "upload_id") "_${uploadId}" else ""
+        val expectedFilename = "${Metadata.getFilePrefixByDate(DateTime.now(), useCase)}/${testFile.nameWithoutExtension}${filenameSuffix}${testFile.extension}"
+        var expectedBlobClient: BlobClient? = null
 
-        Assert.assertNotNull(edavUploadBlob)
-        Assert.assertEquals(edavUploadBlob.properties.blobSize, testFile.length())
-    }
+        if (uploadConfig.copyConfig.targets.contains("edav")) {
+            expectedBlobClient = edavContainerClient.getBlobClient(expectedFilename)
+        } else if (uploadConfig.copyConfig.targets.contains("routing")) {
+            expectedBlobClient = routingContainerClient.getBlobClient(expectedFilename)
+        }
 
-    @Test(groups = [Constants.Groups.FILE_COPY])
-    fun shouldCopyToRoutingContainer() {
-        val expectedFilename = "${Metadata.getFilePrefixByDate(DateTime.now(), useCase)}/${testFile.nameWithoutExtension}_${uploadId}${testFile.extension}"
-        val routingUploadBlob = edavContainerClient.getBlobClient(expectedFilename)
-
-        Assert.assertNotNull(routingUploadBlob)
-        Assert.assertEquals(routingUploadBlob.properties.blobSize, testFile.length())
+        Assert.assertNotNull(expectedBlobClient)
+        Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
     }
 }

--- a/tests/smoke/kotlin/src/test/kotlin/model/CopyConfig.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/model/CopyConfig.kt
@@ -1,0 +1,10 @@
+package model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CopyConfig(
+    @get:JsonProperty("filename_suffix") val filenameSuffix: String,
+    @get:JsonProperty("targets") val targets: List<String>
+)

--- a/tests/smoke/kotlin/src/test/kotlin/model/UploadConfig.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/model/UploadConfig.kt
@@ -1,0 +1,9 @@
+package model
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class UploadConfig(
+    @get:JsonProperty("copy_config") val copyConfig: CopyConfig,
+)

--- a/tests/smoke/kotlin/src/test/kotlin/util/Constants.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/Constants.kt
@@ -5,6 +5,7 @@ class Constants {
         const val TEST_DESTINATION = "dextesting"
         const val TEST_EVENT = "testevent1"
         const val BULK_UPLOAD_CONTAINER_NAME = "bulkuploads"
+        const val UPLOAD_CONFIG_CONTAINER_NAME = "upload-configs"
         const val EDAV_UPLOAD_CONTAINER_NAME = "upload"
         const val ROUTING_UPLOAD_CONTAINER_NAME = "routeingress"
         const val TUS_PREFIX_DIRECTORY_NAME = "tus-prefix"

--- a/tests/smoke/kotlin/src/test/resources/dev/aims-celr-csv.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/aims-celr-csv.xml
@@ -4,11 +4,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Metadata Verify">

--- a/tests/smoke/kotlin/src/test/resources/dev/aims-celr-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/aims-celr-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/daart-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/daart-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/dex-hl7-hl7ingress.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/dex-hl7-hl7ingress.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-aplhistoricaldata.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-aplhistoricaldata.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-covidallmonthlyvaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-covidbridgevaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-covidbridgevaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-influenzavaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-influenzavaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-routineimmunization.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-routineimmunization.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/ndlp-rsvprevention.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/ndlp-rsvprevention.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/dev/pulsenet-localsequencefile.xml
+++ b/tests/smoke/kotlin/src/test/resources/dev/pulsenet-localsequencefile.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/aims-celr-csv.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/aims-celr-csv.xml
@@ -7,11 +7,7 @@
         <parameter name="SENDER_MANIFEST_NO_EVENT" value="no-event.properties" />
         <parameter name="SENDER_MANIFEST_INVALID_FILENAME" value="invalid-filename.properties" />
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Metadata Verify">

--- a/tests/smoke/kotlin/src/test/resources/prd/aims-celr-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/aims-celr-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/daart-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/daart-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/dex-hl7-hl7ingress.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/dex-hl7-hl7ingress.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-aplhistoricaldata.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-aplhistoricaldata.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-covidallmonthlyvaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-covidbridgevaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-covidbridgevaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-influenzavaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-influenzavaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-routineimmunization.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-routineimmunization.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/ndlp-rsvprevention.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/ndlp-rsvprevention.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/prd/pulsenet-localsequencefile.xml
+++ b/tests/smoke/kotlin/src/test/resources/prd/pulsenet-localsequencefile.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/aims-celr-csv.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/aims-celr-csv.xml
@@ -4,11 +4,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Metadata Verify">

--- a/tests/smoke/kotlin/src/test/resources/stg/aims-celr-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/aims-celr-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/daart-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/daart-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/dex-hl7-hl7ingress.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/dex-hl7-hl7ingress.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-aplhistoricaldata.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-aplhistoricaldata.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-covidallmonthlyvaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-covidbridgevaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-covidbridgevaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-influenzavaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-influenzavaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-routineimmunization.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-routineimmunization.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/ndlp-rsvprevention.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/ndlp-rsvprevention.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/stg/pulsenet-localsequencefile.xml
+++ b/tests/smoke/kotlin/src/test/resources/stg/pulsenet-localsequencefile.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/aims-celr-csv.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/aims-celr-csv.xml
@@ -4,11 +4,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-csv.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Metadata Verify">

--- a/tests/smoke/kotlin/src/test/resources/tst/aims-celr-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/aims-celr-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="aims-celr-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/daart-hl7.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/daart-hl7.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="daart-hl7.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToEdavContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/dex-hl7-hl7ingress.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/dex-hl7-hl7ingress.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="dex-hl7-hl7ingress.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-aplhistoricaldata.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-aplhistoricaldata.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-aplhistoricaldata.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-covidallmonthlyvaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-covidallmonthlyvaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidallmonthlyvaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-covidbridgevaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-covidbridgevaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-covidbridgevaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-influenzavaccination.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-influenzavaccination.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-influenzavaccination.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-routineimmunization.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-routineimmunization.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-routineimmunization.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/ndlp-rsvprevention.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/ndlp-rsvprevention.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="ndlp-rsvprevention.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/tests/smoke/kotlin/src/test/resources/tst/pulsenet-localsequencefile.xml
+++ b/tests/smoke/kotlin/src/test/resources/tst/pulsenet-localsequencefile.xml
@@ -13,11 +13,7 @@
     <test name="File Copy">
         <parameter name="SENDER_MANIFEST" value="pulsenet-localsequencefile.properties"/>
         <classes>
-            <class name="FileCopy">
-                <methods>
-                    <exclude name="shouldCopyToRoutingContainer" />
-                </methods>
-            </class>
+            <class name="FileCopy" />
         </classes>
     </test>
     <test name="Proc Stat">

--- a/upload-configs/v1/aims-celr-csv.json
+++ b/upload-configs/v1/aims-celr-csv.json
@@ -68,6 +68,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v1/aims-celr-hl7.json
+++ b/upload-configs/v1/aims-celr-hl7.json
@@ -68,6 +68,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v1/daart-hl7.json
+++ b/upload-configs/v1/daart-hl7.json
@@ -39,6 +39,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v1/dex-hl7-hl7ingress.json
+++ b/upload-configs/v1/dex-hl7-hl7ingress.json
@@ -66,6 +66,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"edav"

--- a/upload-configs/v1/dextesting-testevent1.json
+++ b/upload-configs/v1/dextesting-testevent1.json
@@ -11,6 +11,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing",

--- a/upload-configs/v2/celr-csv.json
+++ b/upload-configs/v2/celr-csv.json
@@ -90,6 +90,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v2/celr-hl7v2.json
+++ b/upload-configs/v2/celr-hl7v2.json
@@ -90,6 +90,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v2/daart-hl7.json
+++ b/upload-configs/v2/daart-hl7.json
@@ -62,6 +62,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing"

--- a/upload-configs/v2/dex-hl7-hl7ingress.json
+++ b/upload-configs/v2/dex-hl7-hl7ingress.json
@@ -88,6 +88,7 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"edav"

--- a/upload-configs/v2/dextesting-testevent1.json
+++ b/upload-configs/v2/dextesting-testevent1.json
@@ -40,6 +40,7 @@
       ]
    },
    "copy_config": {
+      "filename_suffix": "upload_id",
       "folder_structure": "date_YYYY_MM_DD",
       "targets": [
          "routing",

--- a/upload-configs/v2/ehdi-csv.json
+++ b/upload-configs/v2/ehdi-csv.json
@@ -74,6 +74,7 @@
     ]
   },
   "copy_config": {
+    "filename_suffix": "upload_id",
     "folder_structure": "date_YYYY_MM_DD",
     "targets": [
       "routing"

--- a/upload-configs/v2/eicr-fhir.json
+++ b/upload-configs/v2/eicr-fhir.json
@@ -5,7 +5,7 @@
 			{
 				"field_name": "sender_id",
 				"required": true,
-                "allowed_values": [
+				"allowed_values": [
 					"APHL"
 				],
 				"description": "This field is the identifier for the sender of the data."
@@ -13,13 +13,13 @@
 			{
 				"field_name": "data_producer_id",
 				"required": false,
-                "allowed_values": null,
+				"allowed_values": null,
 				"description": "This field is the identifier for the data producer."
 			},
 			{
 				"field_name": "jurisdiction",
 				"required": false,
-                "allowed_values": null,
+				"allowed_values": null,
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null."
 			},
 			{
@@ -30,7 +30,7 @@
 			{
 				"field_name": "data_stream_id",
 				"required": true,
-                "allowed_values": [
+				"allowed_values": [
 					"eicr"
 				],
 				"description": "This field is the identifier for the data stream."
@@ -38,9 +38,9 @@
 			{
 				"field_name": "data_stream_route",
 				"required": true,
-                "allowed_values": [
+				"allowed_values": [
 					"fhir"
-				],				
+				],
 				"description": "This recieved is the route of the data stream."
 			},
 			{
@@ -76,10 +76,11 @@
 		]
 	},
 	"copy_config": {
+		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
 			"routing",
-            "edav"
+			"edav"
 		]
 	}
 }

--- a/upload-configs/v2/nrss-csv.json
+++ b/upload-configs/v2/nrss-csv.json
@@ -56,6 +56,7 @@
     ]
   },
   "copy_config": {
+    "filename_suffix": "upload_id",
     "folder_structure": "date_YYYY_MM_DD",
     "targets": [
       "routing"

--- a/upload-configs/v2/nrss-hl7v2.json
+++ b/upload-configs/v2/nrss-hl7v2.json
@@ -86,6 +86,7 @@
     ]
   },
   "copy_config": {
+    "filename_suffix": "upload_id",
     "folder_structure": "date_YYYY_MM_DD",
     "targets": [
       "routing"

--- a/upload-processor/BulkFileUploadFunctionApp/Model/CopyConfig.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/CopyConfig.cs
@@ -4,6 +4,9 @@ namespace BulkFileUploadFunctionApp.Model
 {
     public record CopyConfig
     {
+        public static string FILENAME_SUFFIX_NONE = "none";
+        public static string FILENAME_SIFFIX_UID = "upload_id";
+        [JsonPropertyName("filename_suffix")] public string? FilenameSuffix { get; init; }
         [JsonPropertyName("folder_structure")] public string? FolderStructure { get; init; }
         [JsonPropertyName("targets")] public List<string>? Targets { get; init; }
         public List<CopyTargetsEnum>? TargetEnums { get; set; }

--- a/upload-processor/BulkFileUploadFunctionApp/Model/UploadConfig.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/UploadConfig.cs
@@ -13,6 +13,7 @@ namespace BulkFileUploadFunctionApp.Model
             MetadataConfig = null,
             CopyConfig = new CopyConfig()
             {
+                FilenameSuffix = CopyConfig.FILENAME_SUFFIX_NONE,
                 FolderStructure = "date_YYYY_MM_DD",
                 TargetEnums = new List<CopyTargetsEnum> { CopyTargetsEnum.edav, CopyTargetsEnum.routing }
             },


### PR DESCRIPTION
Adding back the filename suffix config field to the upload configs.  This is due to NDLP not being able to process files whose filenames have changed.  This is a legitimate use case we need to take into account.  With this change, files will default to no suffix if this setting isn't set, or is set to "none".  Otherwise, it can be set to "upload_id" to append the upload ID to the file during copy.  This will prevent files from being overwritten with the same filename.