### PR TITLE
UPLOAD-1272 v2 config updates

### DIFF
--- a/upload-configs/v2/celr-csv.json
+++ b/upload-configs/v2/celr-csv.json
@@ -5,7 +5,7 @@
 			{
 				"field_name": "sender_id",
 				"allowed_values": [
-					"APHL-CELR"
+					"APHL"
 				],
 				"required": true,
 				"description": "This field is the identifier for the sender of the data.",
@@ -13,17 +13,13 @@
 			},
 			{
 				"field_name": "data_producer_id",
-				"allowed_values": [
-					"DC-TEST"
-				],
+				"allowed_values": null,
 				"required": true,
 				"description": "This field is the identifier for the data producer."
 			},
 			{
 				"field_name": "jurisdiction",
-				"allowed_values": [
-					"DC"
-				],
+				"allowed_values": null,
 				"required": true,
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_organization"

--- a/upload-configs/v2/celr-hl7v2.json
+++ b/upload-configs/v2/celr-hl7v2.json
@@ -5,7 +5,7 @@
 			{
 				"field_name": "sender_id",
 				"allowed_values": [
-					"APHL-CELR"
+					"APHL"
 				],
 				"required": true,
 				"description": "This field is the identifier for the sender of the data.",
@@ -13,17 +13,13 @@
 			},
 			{
 				"field_name": "data_producer_id",
-				"allowed_values": [
-					"DC-TEST"
-				],
+				"allowed_values": null,
 				"required": true,
 				"description": "This field is the identifier for the data producer."
 			},
 			{
 				"field_name": "jurisdiction",
-				"allowed_values": [
-					"DC"
-				],
+				"allowed_values": null,
 				"required": true,
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_organization"


### PR DESCRIPTION
## Updates

- CELR v2 CSV Config - updated sender id to `APHL`; updated data_producer_id and jurisdiction to be required, but allow any value
- CELR v2 HL7v2 Config - updated sender id to `APHL`; updated data_producer_id and jurisdiction to be required, but allow any value