### PR TITLE
Fixup/tusv2 smoke test tweaks

### DIFF
--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import model.UploadConfig
 import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
 import org.testng.Assert
 import org.testng.ITestContext
 import org.testng.TestNGException
@@ -85,8 +86,8 @@ class FileCopy {
     @Test(groups = [Constants.Groups.FILE_COPY])
     fun shouldCopyToDestinationContainers() {
         val filenameSuffix = if (uploadConfig.copyConfig.filenameSuffix == "upload_id") "_${uploadId}" else ""
-        val expectedFilename = "${Metadata.getFilePrefixByDate(DateTime.now(), useCase)}/${testFile.nameWithoutExtension}${filenameSuffix}${testFile.extension}"
-        var expectedBlobClient: BlobClient? = null
+        val expectedFilename = "${Metadata.getFilePrefixByDate(DateTime(DateTimeZone.UTC), useCase)}/${testFile.nameWithoutExtension}${filenameSuffix}${testFile.extension}"
+        var expectedBlobClient: BlobClient?
 
         if (uploadConfig.copyConfig.targets.contains("edav")) {
             expectedBlobClient = edavContainerClient.getBlobClient(expectedFilename)

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -54,7 +54,7 @@ class FileCopy {
 
         uploadConfigBlobClient = dexBlobClient
             .getBlobContainerClient(Constants.UPLOAD_CONFIG_CONTAINER_NAME)
-            .getBlobClient("${USE_CASE}.json")
+            .getBlobClient("v1/${USE_CASE}.json")
         uploadConfig = ObjectMapper().readValue(uploadConfigBlobClient.downloadContent().toString())
 
         edavContainerClient = edavBlobClient.getBlobContainerClient(Constants.EDAV_UPLOAD_CONTAINER_NAME)

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -2,7 +2,7 @@ import auth.AuthClient
 import com.azure.identity.ClientSecretCredentialBuilder
 import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import model.UploadConfig
 import org.joda.time.DateTime
@@ -55,7 +55,7 @@ class FileCopy {
         uploadConfigBlobClient = dexBlobClient
             .getBlobContainerClient(Constants.UPLOAD_CONFIG_CONTAINER_NAME)
             .getBlobClient("v1/${USE_CASE}.json")
-        uploadConfig = ObjectMapper().readValue(uploadConfigBlobClient.downloadContent().toString())
+        uploadConfig = jacksonObjectMapper().readValue(uploadConfigBlobClient.downloadContent().toString())
 
         edavContainerClient = edavBlobClient.getBlobContainerClient(Constants.EDAV_UPLOAD_CONTAINER_NAME)
         routingContainerClient = routingBlobClient.getBlobContainerClient(Constants.ROUTING_UPLOAD_CONTAINER_NAME)
@@ -90,11 +90,16 @@ class FileCopy {
 
         if (uploadConfig.copyConfig.targets.contains("edav")) {
             expectedBlobClient = edavContainerClient.getBlobClient(expectedFilename)
-        } else if (uploadConfig.copyConfig.targets.contains("routing")) {
-            expectedBlobClient = routingContainerClient.getBlobClient(expectedFilename)
+
+            Assert.assertNotNull(expectedBlobClient)
+            Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
         }
 
-        Assert.assertNotNull(expectedBlobClient)
-        Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
+        if (uploadConfig.copyConfig.targets.contains("routing")) {
+            expectedBlobClient = routingContainerClient.getBlobClient(expectedFilename)
+
+            Assert.assertNotNull(expectedBlobClient)
+            Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
+        }
     }
 }

--- a/tests/smoke/kotlin/src/test/kotlin/MetadataVerify.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/MetadataVerify.kt
@@ -54,7 +54,7 @@ class MetadataVerify {
     @Test(
         groups = [Constants.Groups.METADATA_VERIFY],
         expectedExceptions = [ProtocolException::class],
-        expectedExceptionsMessageRegExp = ".*Missing one or more required metadata fields.*")
+        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*")
     fun shouldReturnErrorWhenDestinationIDNotProvided() {
         uploadClient.uploadFile(testFile, metadataNoDestId)
     }
@@ -62,7 +62,7 @@ class MetadataVerify {
     @Test(
         groups = [Constants.Groups.METADATA_VERIFY],
         expectedExceptions = [ProtocolException::class],
-        expectedExceptionsMessageRegExp = ".*Missing one or more required metadata fields.*"
+        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*"
     )
     fun shouldReturnErrorWhenEventNotProvided() {
         uploadClient.uploadFile(testFile, metadataNoEvent)
@@ -71,7 +71,7 @@ class MetadataVerify {
     @Test(groups = [
         Constants.Groups.METADATA_VERIFY],
         expectedExceptions = [ProtocolException::class],
-        expectedExceptionsMessageRegExp = ".*Missing required metadata .*filename.*"
+        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*field filename was missing"
     )
     fun shouldReturnErrorWhenFilenameNotProvided() {
         val metadata = hashMapOf(
@@ -86,7 +86,7 @@ class MetadataVerify {
     @Test(groups = [
         Constants.Groups.METADATA_VERIFY],
         expectedExceptions = [ProtocolException::class],
-        expectedExceptionsMessageRegExp = ".*Filename .* contains invalid characters.*"
+        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*invalid character found.*"
     )
     fun shouldReturnErrorWhenFilenameContainsInvalidChars() {
         uploadClient.uploadFile(testFile, metadataInvalidFilename)

--- a/tests/smoke/kotlin/src/test/kotlin/model/CopyConfig.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/model/CopyConfig.kt
@@ -5,6 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class CopyConfig(
-    @get:JsonProperty("filename_suffix") val filenameSuffix: String,
+    @get:JsonProperty("filename_suffix") val filenameSuffix: String? = "none",
     @get:JsonProperty("targets") val targets: List<String>
 )


### PR DESCRIPTION
This patch is to address new functionality changes with the rollout of the v2 upload server.  It also includes general improvements, such as using UTC time so generate the date prefix for blob clients.