### PR TITLE
eICR Target Config remove edav routing

### DIFF
--- a/upload-configs/v2/eicr-fhir.json
+++ b/upload-configs/v2/eicr-fhir.json
@@ -61,8 +61,7 @@
 		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
 		"targets": [
-			"routing",
-			"edav"
+			"routing"
 		]
 	}
 }


### PR DESCRIPTION
## Updates

- eICR sender manifest configuration update - remove edav as a destination target for upload router