### PR TITLE
Structure refactor: extracting manifest fetching for broader use

### DIFF
--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -31,19 +31,20 @@ func GetHookHandler(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error)
 func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) {
 	handler := &prebuilthooks.PrebuiltHook{}
 
-	manifestValidator := metadata.SenderManifestVerification{
+	cache := &metadata.ConfigCache{
 		Loader: &fileloader.FileConfigLoader{
 			FileSystem: os.DirFS(appConfig.UploadConfigPath),
 		},
+	}
+
+	manifestValidator := metadata.SenderManifestVerification{
+		Configs: cache,
 		Reporter: &filereporters.FileReporter{
 			Dir: appConfig.LocalReportsFolder,
 		},
 	}
 
 	postReceiveHook := metadata.HookEventHandler{
-		//Loader: &FileConfigLoader{
-		//	FileSystem: os.DirFS(appConfig.UploadConfigPath),
-		//},
 		Reporter: &filereporters.FileReporter{
 			Dir: appConfig.LocalReportsFolder,
 		},
@@ -54,7 +55,7 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		if err != nil {
 			return nil, err
 		}
-		manifestValidator.Loader = &azureloader.AzureConfigLoader{
+		cache.Loader = &azureloader.AzureConfigLoader{
 			Client:        client,
 			ContainerName: appConfig.AzureManifestConfigContainer,
 		}

--- a/upload-server/internal/metadata/validation/validation.go
+++ b/upload-server/internal/metadata/validation/validation.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-type UploadConfig struct {
+type ManifestConfig struct {
 	Metadata MetadataConfig `json:"metadata_config"`
 	Copy     CopyConfig     `json:"copy_config"`
 }


### PR DESCRIPTION
Now other aspects, hooks at the moment, can easily access the same logic getting manifest configs. e.g. 
```go
key, _ := metadata.GetConfigIdentifierByVersion(context.TODO, metadata)
c, _ := cache.GetConfig(key)
c.Copy
```

Another eventual improvement can be to move this one level higher into main.go, where it will then be more easily accessible to any component.