### PR TITLE
UPLOAD-1341 Support backwards compatible upload config filenames

### DIFF
--- a/upload-configs/v1/aims-celr-csv.json
+++ b/upload-configs/v1/aims-celr-csv.json
@@ -73,5 +73,6 @@
 		"targets": [
 			"routing"
 		]
-	}
+	},
+	"compat_config_filename": "celr-csv.json"
 }

--- a/upload-configs/v1/aims-celr-hl7.json
+++ b/upload-configs/v1/aims-celr-hl7.json
@@ -73,5 +73,6 @@
 		"targets": [
 			"routing"
 		]
-	}
+	},
+	"compat_config_filename": "celr-hl7.json"
 }

--- a/upload-processor/BulkFileUploadFunctionApp/Model/UploadConfig.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Model/UploadConfig.cs
@@ -7,6 +7,7 @@ namespace BulkFileUploadFunctionApp.Model
     {
         [JsonPropertyName("metadata_config")] public MetadataConfig? MetadataConfig { get; init; }
         [JsonPropertyName("copy_config")] public CopyConfig? CopyConfig { get; init; }
+        [JsonPropertyName("compat_config_filename")] public string? CompatComfigFilename {  get; init; }
 
         public static readonly UploadConfig Default = new UploadConfig()
         {

--- a/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
+++ b/upload-processor/BulkFileUploadFunctionApp/Services/UploadProcessingService.cs
@@ -112,7 +112,16 @@ namespace BulkFileUploadFunctionApp.Services
                 // translate V1 metadata 
                 if (version == MetadataVersion.V1)
                 {
-                    var uploadConfigV2 = await GetUploadConfig(uploadConfigFilename, MetadataVersion.V2);
+                    // Get metadata v2 config filename.
+                    // Default to v1 filename.
+                    string uploadConfigV2Filename = uploadConfigFilename;
+
+                    if (!String.IsNullOrEmpty(uploadConfig.CompatComfigFilename))
+                    {
+                        uploadConfigV2Filename = uploadConfig.CompatComfigFilename;
+                    }
+
+                    var uploadConfigV2 = await GetUploadConfig(uploadConfigV2Filename, MetadataVersion.V2);
                     _logger.LogInformation($"Translating to {JsonSerializer.Serialize(uploadConfigV2)}");
                     tusInfoFile.MetaData = TranslateMetadata(tusInfoFile.MetaData, uploadConfigV2);
                 }
@@ -393,6 +402,7 @@ namespace BulkFileUploadFunctionApp.Services
         {
             var uploadConfig = UploadConfig.Default;
             var configFilename = $"{versionNum.ToString().ToLower()}/{filename}";
+            _logger.LogInformation($"Getting upload config file {configFilename}");
 
             try
             {


### PR DESCRIPTION
This patch is to address a potential issue when transitioning senders from v1 to v2 sender manifest definitions.  Currently, we have a limitation where the v1 and v2 config filenames must match.  If they don't, the upload processor will throw an error as it will be unable to find the v2 config file given v1 use case identifiers if the identifiers are different across versions.

Ex:
v1 destination ID is `myprogram` and event type is `superawesomeevent`.  
v2 data stream ID is `mynewprogram` and data stream route is `superroute`.

Given a v1 manifest, the upload processor will look for upload config files named `myprogram-superawesomeevent.json` for both v1 and v2 configs.  This will result in an error.

This patch adds a field to the upload config called `compat_config_filename` that links a v1 config file to a v2 config file.  This is an optional field.  If it is provided, the upload processor will use it to find the v2 config file.  If it's not, it will revert to the old behavior and use the use case identifiers.

A good test case for this is the AIMS CELR use case.  In v1, their config filename is aims-celr-csv.json.  In v2, it's just celr-csv.json.  Uploading a file for aims-celr-csv should map to celr-csv.