### PR TITLE
fix compat filename for v2 celr hl7

### DIFF
--- a/upload-configs/v1/aims-celr-hl7.json
+++ b/upload-configs/v1/aims-celr-hl7.json
@@ -74,5 +74,5 @@
 			"routing"
 		]
 	},
-	"compat_config_filename": "celr-hl7.json"
+	"compat_config_filename": "celr-hl7v2.json"
 }


### PR DESCRIPTION
Fixing the compat config filename value to match the v2 upload config filename for celr hl7.