### PR TITLE
Upload 1249/server health check service bus

### DIFF
--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -16,16 +16,6 @@ import (
 )
 
 func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
-
-	// initialize processing status health checker
-	// psHealth, err := pshealth.New(appConfig)
-	// if err != nil {
-	// 	logger.Error("error initialize processing status health check", "error", err)
-	// } // .if
-	// if psHealth != nil {
-	// 	health.Register(psHealth)
-	// } // .if
-
 	// Register health check for PS API service bus.
 	sbHealth, err := sbhealth.New(appConfig)
 	if err != nil {

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/handlerdex"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/handlertusd"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/pshealth"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/sbhealth"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/redislocker"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/tus/tusd/v2/pkg/hooks"
@@ -18,13 +18,22 @@ import (
 func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 
 	// initialize processing status health checker
-	psHealth, err := pshealth.New(appConfig)
+	// psHealth, err := pshealth.New(appConfig)
+	// if err != nil {
+	// 	logger.Error("error initialize processing status health check", "error", err)
+	// } // .if
+	// if psHealth != nil {
+	// 	health.Register(psHealth)
+	// } // .if
+
+	// Register health check for PS API service bus.
+	sbHealth, err := sbhealth.New(appConfig)
 	if err != nil {
-		logger.Error("error initialize processing status health check", "error", err)
-	} // .if
-	if psHealth != nil {
-		health.Register(psHealth)
-	} // .if
+		logger.Error("error initializing service bus health check", "error", err)
+	}
+	if sbHealth != nil {
+		health.Register(sbHealth)
+	}
 
 	// create and register data store
 	store, storeHealthCheck, err := GetDataStore(appConfig)
@@ -76,7 +85,7 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	http.Handle(pathWithSlash, http.StripPrefix(pathWithSlash, handlerTusd))
 
 	// initialize and route handler for DEX
-	handlerDex := handlerdex.New(appConfig, psHealth)
+	handlerDex := handlerdex.New(appConfig)
 	http.Handle("/", handlerDex)
 
 	// --------------------------------------------------------------

--- a/upload-server/internal/handlerdex/handlerdex.go
+++ b/upload-server/internal/handlerdex/handlerdex.go
@@ -20,9 +20,6 @@ type HandlerDex struct {
 	TusAzBlobClient    *azblob.Client
 	RouterAzBlobClient *azblob.Client
 	EdavAzBlobClient   *azblob.Client
-
-	// processing status
-	// psHealth *pshealth.PsHealth
 } // .HandlerDex
 
 // New returns a DEX sever handler that can handle http requests
@@ -38,7 +35,6 @@ func New(appConfig appconfig.AppConfig) *HandlerDex {
 	return &HandlerDex{
 		appConfig: appConfig,
 		logger:    logger,
-		// psHealth:  psHealth,
 	} // .&HandlerDex
 } // .New
 

--- a/upload-server/internal/handlerdex/handlerdex.go
+++ b/upload-server/internal/handlerdex/handlerdex.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/pshealth"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/sloger"
 ) // .import
 
@@ -23,11 +22,11 @@ type HandlerDex struct {
 	EdavAzBlobClient   *azblob.Client
 
 	// processing status
-	psHealth *pshealth.PsHealth
+	// psHealth *pshealth.PsHealth
 } // .HandlerDex
 
 // New returns a DEX sever handler that can handle http requests
-func New(appConfig appconfig.AppConfig, psHealth *pshealth.PsHealth) *HandlerDex {
+func New(appConfig appconfig.AppConfig) *HandlerDex {
 
 	type Empty struct{}
 	pkgParts := strings.Split(reflect.TypeOf(Empty{}).PkgPath(), "/")
@@ -39,7 +38,7 @@ func New(appConfig appconfig.AppConfig, psHealth *pshealth.PsHealth) *HandlerDex
 	return &HandlerDex{
 		appConfig: appConfig,
 		logger:    logger,
-		psHealth:  psHealth,
+		// psHealth:  psHealth,
 	} // .&HandlerDex
 } // .New
 

--- a/upload-server/internal/models/consts.go
+++ b/upload-server/internal/models/consts.go
@@ -10,6 +10,7 @@ const (
 	AZ_BLOB_CLIENT_NA      = "error: client not available, check config"
 	//
 	PROCESSING_STATUS_APP = "Processing Status"
+	SERVICE_BUS           = "Azure Service Bus"
 
 	META_DESTINATION_ID = "meta_destination_id"
 	META_EXT_EVENT      = "meta_ext_event"

--- a/upload-server/internal/sbhealth/sbhealth.go
+++ b/upload-server/internal/sbhealth/sbhealth.go
@@ -3,7 +3,9 @@ package sbhealth
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/models"
@@ -16,8 +18,14 @@ type ServiceBusHealth struct {
 }
 
 func New(appConfig appconfig.AppConfig) (*ServiceBusHealth, error) {
-	// TODO set retry options.
-	client, err := admin.NewClientFromConnectionString(appConfig.ServiceBusConnectionString, nil)
+	client, err := admin.NewClientFromConnectionString(appConfig.ServiceBusConnectionString, &admin.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Retry: policy.RetryOptions{
+				MaxRetries: 3,
+				RetryDelay: 1 * time.Second,
+			},
+		},
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/upload-server/internal/sbhealth/sbhealth.go
+++ b/upload-server/internal/sbhealth/sbhealth.go
@@ -1,8 +1,12 @@
 package sbhealth
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/models"
 )
 
 // Service Bus
@@ -22,4 +26,33 @@ func New(appConfig appconfig.AppConfig) (*ServiceBusHealth, error) {
 		Client: client,
 		Queue:  appConfig.ReportQueueName,
 	}, nil
+}
+
+func (sbHealth ServiceBusHealth) Health(ctx context.Context) models.ServiceHealthResp {
+	var shr models.ServiceHealthResp
+	shr.Service = models.SERVICE_BUS
+
+	// Get the service bus queue.
+	queueResp, err := sbHealth.Client.GetQueue(ctx, sbHealth.Queue, nil)
+	if err != nil {
+		return serviceBusDown(err)
+	}
+
+	// Check the queue status is active.
+	if *queueResp.Status != admin.EntityStatusActive {
+		return serviceBusDown(fmt.Errorf("service bus queue status: %s", *queueResp.Status))
+	}
+
+	// all good
+	shr.Status = models.STATUS_UP
+	shr.HealthIssue = models.HEALTH_ISSUE_NONE
+	return shr
+}
+
+func serviceBusDown(err error) models.ServiceHealthResp {
+	return models.ServiceHealthResp{
+		Service:     models.SERVICE_BUS,
+		Status:      models.STATUS_DOWN,
+		HealthIssue: err.Error(),
+	}
 }

--- a/upload-server/internal/sbhealth/sbhealth.go
+++ b/upload-server/internal/sbhealth/sbhealth.go
@@ -1,0 +1,25 @@
+package sbhealth
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus/admin"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
+)
+
+// Service Bus
+type ServiceBusHealth struct {
+	Client *admin.Client
+	Queue  string
+}
+
+func New(appConfig appconfig.AppConfig) (*ServiceBusHealth, error) {
+	// TODO set retry options.
+	client, err := admin.NewClientFromConnectionString(appConfig.ServiceBusConnectionString, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceBusHealth{
+		Client: client,
+		Queue:  appConfig.ReportQueueName,
+	}, nil
+}


### PR DESCRIPTION
Expands the upload service health endpoint to include a check on the PS API service bus report queue, and removes the health check for the PS API HTTP health check endpoint.

Testing steps:
1. Run locally with the SERVICE_BUS_CONNECTION_STR env var set
2. Send an HTTP GET to `http://localhost:8080/health`
3. You should get back a 200 response with a JSON response that looks like this:
```
{
    "status": "UP",
    "services": [
        {
            "service": "Azure Service Bus",
            "status": "UP",
            "health_issue": "None reported"
        },
        {
            "service": "Tus storage",
            "status": "UP",
            "health_issue": "None reported"
        }
    ]
}
```