### PR TITLE
Delivery Connection Resiliance and Health Check

### DIFF
--- a/upload-server/cmd/cli/datastore.go
+++ b/upload-server/cmd/cli/datastore.go
@@ -71,7 +71,7 @@ type FileStoreHealthCheck struct {
 	path string
 }
 
-func (c *FileStoreHealthCheck) Health(ctx context.Context) (rsp models.ServiceHealthResp) {
+func (c *FileStoreHealthCheck) Health(_ context.Context) (rsp models.ServiceHealthResp) {
 	rsp.Service = "File Storage"
 	info, err := os.Stat(c.path)
 	if err != nil {

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/upload"
 	"os"
 
@@ -43,23 +42,25 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		Path: appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix,
 	}
 
-	postprocessing.RegisterTarget("dex", &postprocessing.FileDeliverer{
-		ToPath: appConfig.LocalDEXFolder,
-		From:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
-	})
-
-	postprocessing.RegisterTarget("edav", &postprocessing.FileDeliverer{
-		ToPath: appConfig.LocalEDAVFolder,
-		From:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
-	})
-
-	postprocessing.RegisterTarget("routing", &postprocessing.FileDeliverer{
-		ToPath: appConfig.LocalROUTINGFolder,
-		From:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
-	})
+	//postprocessing.RegisterTarget("dex", &postprocessing.FileDeliverer{
+	//	LocalStorageConfig: appconfig.LocalStorageConfig{
+	//		ToPath: appConfig.LocalDEXFolder,
+	//		FromPath:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
+	//	},
+	//})
+	//
+	//postprocessing.RegisterTarget("edav", &postprocessing.FileDeliverer{
+	//	ToPath: appConfig.LocalEDAVFolder,
+	//	From:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
+	//})
+	//
+	//postprocessing.RegisterTarget("routing", &postprocessing.FileDeliverer{
+	//	ToPath: appConfig.LocalRoutingFolder,
+	//	From:   os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix),
+	//})
 
 	if appConfig.AzureConnection != nil {
-		ctx := context.Background()
+		//ctx := context.Background()
 		client, err := storeaz.NewBlobClient(*appConfig.AzureConnection)
 		if err != nil {
 			return nil, err
@@ -73,59 +74,59 @@ func PrebuiltHooks(appConfig appconfig.AppConfig) (tusHooks.HookHandler, error) 
 		if err != nil {
 			return nil, err
 		}
-		dexCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.AzureConnection, appConfig.DexCheckpointContainer)
-		if err != nil {
-			return nil, err
-		}
-		err = storeaz.CreateContainerIfNotExists(ctx, dexCheckpointContainerClient)
-		if err != nil {
-			return nil, err
-		}
-
-		postprocessing.RegisterTarget("dex", &postprocessing.AzureDeliverer{
-			FromContainerClient: tusContainerClient,
-			ToContainerClient:   dexCheckpointContainerClient,
-			TusPrefix:           appConfig.TusUploadPrefix,
-			Target:              "dex",
-		})
+		//dexCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.AzureConnection, appConfig.DexCheckpointContainer)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//err = storeaz.CreateContainerIfNotExists(ctx, dexCheckpointContainerClient)
+		//if err != nil {
+		//	return nil, err
+		//}
+		//
+		//postprocessing.RegisterTarget("dex", &postprocessing.AzureDeliverer{
+		//	FromContainerClient: tusContainerClient,
+		//	ToContainerClient:   dexCheckpointContainerClient,
+		//	TusPrefix:           appConfig.TusUploadPrefix,
+		//	Target:              "dex",
+		//})
 
 		// Connect to delivery storage accounts if we have their connection configs.
-		// If we don't, maybe we try and establish a connection?
+		// If we don't, maybe we try and establish a connection later?
 		// Maybe health check checks for storage config too?
-		if appConfig.EdavConnection != nil {
-			edavCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.EdavConnection, appConfig.EdavCheckpointContainer)
-			if err != nil {
-				return nil, err
-			}
-			err = storeaz.CreateContainerIfNotExists(ctx, edavCheckpointContainerClient)
-			if err != nil {
-				return nil, err
-			}
-
-			postprocessing.RegisterTarget("edav", &postprocessing.AzureDeliverer{
-				FromContainerClient: tusContainerClient,
-				ToContainerClient:   edavCheckpointContainerClient,
-				TusPrefix:           appConfig.TusUploadPrefix,
-				Target:              "edav",
-			})
-		}
-
-		if appConfig.RoutingConnection != nil {
-			routingCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.RoutingConnection, appConfig.RoutingCheckpointContainer)
-			if err != nil {
-				return nil, err
-			}
-			err = storeaz.CreateContainerIfNotExists(ctx, routingCheckpointContainerClient)
-			if err != nil {
-				return nil, err
-			}
-			postprocessing.RegisterTarget("routing", &postprocessing.AzureDeliverer{
-				FromContainerClient: tusContainerClient,
-				ToContainerClient:   routingCheckpointContainerClient,
-				TusPrefix:           appConfig.TusUploadPrefix,
-				Target:              "routing",
-			})
-		}
+		//if appConfig.EdavConnection != nil {
+		//	edavCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.EdavConnection, appConfig.EdavCheckpointContainer)
+		//	if err != nil {
+		//		return nil, err
+		//	}
+		//	err = storeaz.CreateContainerIfNotExists(ctx, edavCheckpointContainerClient)
+		//	if err != nil {
+		//		return nil, err
+		//	}
+		//
+		//	postprocessing.RegisterTarget("edav", &postprocessing.AzureDeliverer{
+		//		FromContainerClient: tusContainerClient,
+		//		ToContainerClient:   edavCheckpointContainerClient,
+		//		TusPrefix:           appConfig.TusUploadPrefix,
+		//		Target:              "edav",
+		//	})
+		//}
+		//
+		//if appConfig.RoutingConnection != nil {
+		//	routingCheckpointContainerClient, err := storeaz.NewContainerClient(*appConfig.RoutingConnection, appConfig.RoutingCheckpointContainer)
+		//	if err != nil {
+		//		return nil, err
+		//	}
+		//	err = storeaz.CreateContainerIfNotExists(ctx, routingCheckpointContainerClient)
+		//	if err != nil {
+		//		return nil, err
+		//	}
+		//	postprocessing.RegisterTarget("routing", &postprocessing.AzureDeliverer{
+		//		FromContainerClient: tusContainerClient,
+		//		ToContainerClient:   routingCheckpointContainerClient,
+		//		TusPrefix:           appConfig.TusUploadPrefix,
+		//		Target:              "routing",
+		//	})
+		//}
 
 		metadataAppender = &metadata.AzureMetadataAppender{
 			ContainerClient: tusContainerClient,

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -84,33 +84,29 @@ func PrebuiltHooks(ctx context.Context, appConfig appconfig.AppConfig) (tusHooks
 			postprocessing.RegisterTarget("dex", dexAzureDeliverer)
 			health.Register(dexAzureDeliverer)
 		}
+		if appConfig.EdavConnection != nil {
+			edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
+			if err != nil {
+				logger.Error("failed to connect to edav deliverer target", "error", err.Error())
+			} else {
+				postprocessing.RegisterTarget("edav", edavAzureDeliverer)
+				health.Register(edavAzureDeliverer)
+			}
+		}
+		if appConfig.RoutingConnection != nil {
+			routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
+			if err != nil {
+				logger.Error("failed to connect to router deliverer target", "error", err.Error())
+			} else {
+				postprocessing.RegisterTarget("routing", routingAzureDeliverer)
+				health.Register(routingAzureDeliverer)
+			}
+		}
 	} else {
 		postprocessing.RegisterTarget("dex", dexFileDeliverer)
 		health.Register(dexFileDeliverer)
-	}
-
-	if appConfig.EdavConnection != nil {
-		edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
-		if err != nil {
-			logger.Error("failed to connect to edav deliverer target", "error", err.Error())
-		} else {
-			postprocessing.RegisterTarget("edav", edavAzureDeliverer)
-			health.Register(edavAzureDeliverer)
-		}
-	} else {
 		postprocessing.RegisterTarget("edav", edavFileDeliverer)
 		health.Register(edavFileDeliverer)
-	}
-
-	if appConfig.RoutingConnection != nil {
-		routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
-		if err != nil {
-			logger.Error("failed to connect to router deliverer target", "error", err.Error())
-		} else {
-			postprocessing.RegisterTarget("routing", routingAzureDeliverer)
-			health.Register(routingAzureDeliverer)
-		}
-	} else {
 		postprocessing.RegisterTarget("routing", routingFileDeliverer)
 		health.Register(routingFileDeliverer)
 	}

--- a/upload-server/cmd/cli/hooks.go
+++ b/upload-server/cmd/cli/hooks.go
@@ -40,22 +40,9 @@ func PrebuiltHooks(ctx context.Context, appConfig appconfig.AppConfig) (tusHooks
 	}
 
 	var metadataAppender metadata.Appender
-	metadataAppender = &metadata.FileMetadataAppender{
-		Path: appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix,
-	}
-
-	dexFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "dex", &appConfig)
-	if err != nil {
-		return nil, err
-	}
-	edavFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "edav", &appConfig)
-	if err != nil {
-		return nil, err
-	}
-	routingFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "routing", &appConfig)
-	if err != nil {
-		return nil, err
-	}
+	var dexDeliverer postprocessing.Deliverer
+	var edavDeliverer postprocessing.Deliverer
+	var routingDeliverer postprocessing.Deliverer
 
 	if appConfig.AzureConnection != nil {
 		client, err := storeaz.NewBlobClient(*appConfig.AzureConnection)
@@ -77,38 +64,54 @@ func PrebuiltHooks(ctx context.Context, appConfig appconfig.AppConfig) (tusHooks
 			TusPrefix:       appConfig.TusUploadPrefix,
 		}
 
-		dexAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
+		dexDeliverer, err = postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
 		if err != nil {
 			logger.Error("failed to connect to dex deliverer target", "error", err.Error())
 		} else {
-			postprocessing.RegisterTarget("dex", dexAzureDeliverer)
-			health.Register(dexAzureDeliverer)
+			postprocessing.RegisterTarget("dex", dexDeliverer)
+			health.Register(dexDeliverer)
 		}
 		if appConfig.EdavConnection != nil {
-			edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
+			edavDeliverer, err = postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
 			if err != nil {
 				logger.Error("failed to connect to edav deliverer target", "error", err.Error())
 			} else {
-				postprocessing.RegisterTarget("edav", edavAzureDeliverer)
-				health.Register(edavAzureDeliverer)
+				postprocessing.RegisterTarget("edav", edavDeliverer)
+				health.Register(edavDeliverer)
 			}
 		}
 		if appConfig.RoutingConnection != nil {
-			routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
+			routingDeliverer, err = postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
 			if err != nil {
 				logger.Error("failed to connect to router deliverer target", "error", err.Error())
 			} else {
-				postprocessing.RegisterTarget("routing", routingAzureDeliverer)
-				health.Register(routingAzureDeliverer)
+				postprocessing.RegisterTarget("routing", routingDeliverer)
+				health.Register(routingDeliverer)
 			}
 		}
 	} else {
-		postprocessing.RegisterTarget("dex", dexFileDeliverer)
-		health.Register(dexFileDeliverer)
-		postprocessing.RegisterTarget("edav", edavFileDeliverer)
-		health.Register(edavFileDeliverer)
-		postprocessing.RegisterTarget("routing", routingFileDeliverer)
-		health.Register(routingFileDeliverer)
+		metadataAppender = &metadata.FileMetadataAppender{
+			Path: appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix,
+		}
+
+		dexDeliverer, err := postprocessing.NewFileDeliverer(ctx, "dex", &appConfig)
+		if err != nil {
+			return nil, err
+		}
+		postprocessing.RegisterTarget("dex", dexDeliverer)
+		health.Register(dexDeliverer)
+		edavDeliverer, err := postprocessing.NewFileDeliverer(ctx, "edav", &appConfig)
+		if err != nil {
+			return nil, err
+		}
+		postprocessing.RegisterTarget("edav", edavDeliverer)
+		health.Register(edavDeliverer)
+		routingDeliverer, err := postprocessing.NewFileDeliverer(ctx, "routing", &appConfig)
+		if err != nil {
+			return nil, err
+		}
+		postprocessing.RegisterTarget("routing", routingDeliverer)
+		health.Register(routingDeliverer)
 	}
 
 	handler.Register(tusHooks.HookPreCreate, metadata.WithUploadID, metadata.WithTimestamp, manifestValidator.Verify)

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"fmt"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 	"net/http"
 	"strings"
@@ -62,7 +61,6 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 		postprocessing.RegisterTarget("dex", dexAzureDeliverer)
 		health.Register(dexAzureDeliverer)
 	} else {
-		fmt.Printf("***Registering file deliverer for dex")
 		postprocessing.RegisterTarget("dex", dexFileDeliverer)
 		health.Register(dexFileDeliverer)
 	}
@@ -74,10 +72,11 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	if appConfig.EdavConnection != nil {
 		edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
 		if err != nil {
-			return nil, err
+			logger.Error("failed to connect to edav deliverer target", err.Error())
+		} else {
+			postprocessing.RegisterTarget("edav", edavAzureDeliverer)
+			health.Register(edavAzureDeliverer)
 		}
-		postprocessing.RegisterTarget("edav", edavAzureDeliverer)
-		health.Register(edavAzureDeliverer)
 	} else {
 		postprocessing.RegisterTarget("edav", edavFileDeliverer)
 		health.Register(edavFileDeliverer)
@@ -90,10 +89,11 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	if appConfig.RoutingConnection != nil {
 		routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
 		if err != nil {
-			return nil, err
+			logger.Error("failed to connect to router deliverer target", err.Error())
+		} else {
+			postprocessing.RegisterTarget("routing", routingAzureDeliverer)
+			health.Register(routingAzureDeliverer)
 		}
-		postprocessing.RegisterTarget("routing", routingAzureDeliverer)
-		health.Register(routingAzureDeliverer)
 	} else {
 		postprocessing.RegisterTarget("routing", routingFileDeliverer)
 		health.Register(routingFileDeliverer)

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -39,66 +39,6 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	} // .if
 	health.Register(storeHealthCheck)
 
-	// Get one or more health checks for delivery stores.
-	// Maybe register deliverers at this level, and register health checks for them.
-	// Don't need to call postprocessing.RegisterTarget in hooks.go.  Can do it here if we want.
-	// Something like...
-	// dexDeliverer = postProcessing.GetDeliverer("dex", appConfig)
-	// health.Register(dexDeliverer)
-	// postProcessing.RegisterDeliverer(dexDeliverer)
-	//ctx := context.TODO()
-	//// TODO can this just be of type deliverer interface?
-	//dexFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "dex", &appConfig)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if appConfig.AzureConnection != nil {
-	//	dexAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
-	//	if err != nil {
-	//		logger.Error("failed to connect to dex deliverer target", "error", err.Error())
-	//	} else {
-	//		postprocessing.RegisterTarget("dex", dexAzureDeliverer)
-	//		health.Register(dexAzureDeliverer)
-	//	}
-	//} else {
-	//	postprocessing.RegisterTarget("dex", dexFileDeliverer)
-	//	health.Register(dexFileDeliverer)
-	//}
-	//
-	//edavFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "edav", &appConfig)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if appConfig.EdavConnection != nil {
-	//	edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
-	//	if err != nil {
-	//		logger.Error("failed to connect to edav deliverer target", "error", err.Error())
-	//	} else {
-	//		postprocessing.RegisterTarget("edav", edavAzureDeliverer)
-	//		health.Register(edavAzureDeliverer)
-	//	}
-	//} else {
-	//	postprocessing.RegisterTarget("edav", edavFileDeliverer)
-	//	health.Register(edavFileDeliverer)
-	//}
-	//
-	//routingFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "routing", &appConfig)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//if appConfig.RoutingConnection != nil {
-	//	routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
-	//	if err != nil {
-	//		logger.Error("failed to connect to router deliverer target", "error", err.Error())
-	//	} else {
-	//		postprocessing.RegisterTarget("routing", routingAzureDeliverer)
-	//		health.Register(routingAzureDeliverer)
-	//	}
-	//} else {
-	//	postprocessing.RegisterTarget("routing", routingFileDeliverer)
-	//	health.Register(routingFileDeliverer)
-	//}
-
 	uploadInfoHandler, err := GetUploadInfoHandler(&appConfig)
 	if err != nil {
 		logger.Error("error configuring upload info handler: ", "error", err)

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 	"net/http"
 	"strings"
 
@@ -47,58 +46,58 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	// dexDeliverer = postProcessing.GetDeliverer("dex", appConfig)
 	// health.Register(dexDeliverer)
 	// postProcessing.RegisterDeliverer(dexDeliverer)
-	ctx := context.TODO()
-	// TODO can this just be of type deliverer interface?
-	dexFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "dex")
-	if err != nil {
-		return nil, err
-	}
-	if appConfig.AzureConnection != nil {
-		dexAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
-		if err != nil {
-			logger.Error("failed to connect to dex deliverer target", err.Error())
-		} else {
-			postprocessing.RegisterTarget("dex", dexAzureDeliverer)
-			health.Register(dexAzureDeliverer)
-		}
-	} else {
-		postprocessing.RegisterTarget("dex", dexFileDeliverer)
-		health.Register(dexFileDeliverer)
-	}
-
-	edavFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "edav")
-	if err != nil {
-		return nil, err
-	}
-	if appConfig.EdavConnection != nil {
-		edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
-		if err != nil {
-			logger.Error("failed to connect to edav deliverer target", err.Error())
-		} else {
-			postprocessing.RegisterTarget("edav", edavAzureDeliverer)
-			health.Register(edavAzureDeliverer)
-		}
-	} else {
-		postprocessing.RegisterTarget("edav", edavFileDeliverer)
-		health.Register(edavFileDeliverer)
-	}
-
-	routingFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "routing")
-	if err != nil {
-		return nil, err
-	}
-	if appConfig.RoutingConnection != nil {
-		routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
-		if err != nil {
-			logger.Error("failed to connect to router deliverer target", err.Error())
-		} else {
-			postprocessing.RegisterTarget("routing", routingAzureDeliverer)
-			health.Register(routingAzureDeliverer)
-		}
-	} else {
-		postprocessing.RegisterTarget("routing", routingFileDeliverer)
-		health.Register(routingFileDeliverer)
-	}
+	//ctx := context.TODO()
+	//// TODO can this just be of type deliverer interface?
+	//dexFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "dex", &appConfig)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//if appConfig.AzureConnection != nil {
+	//	dexAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
+	//	if err != nil {
+	//		logger.Error("failed to connect to dex deliverer target", "error", err.Error())
+	//	} else {
+	//		postprocessing.RegisterTarget("dex", dexAzureDeliverer)
+	//		health.Register(dexAzureDeliverer)
+	//	}
+	//} else {
+	//	postprocessing.RegisterTarget("dex", dexFileDeliverer)
+	//	health.Register(dexFileDeliverer)
+	//}
+	//
+	//edavFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "edav", &appConfig)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//if appConfig.EdavConnection != nil {
+	//	edavAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "edav", &appConfig)
+	//	if err != nil {
+	//		logger.Error("failed to connect to edav deliverer target", "error", err.Error())
+	//	} else {
+	//		postprocessing.RegisterTarget("edav", edavAzureDeliverer)
+	//		health.Register(edavAzureDeliverer)
+	//	}
+	//} else {
+	//	postprocessing.RegisterTarget("edav", edavFileDeliverer)
+	//	health.Register(edavFileDeliverer)
+	//}
+	//
+	//routingFileDeliverer, err := postprocessing.NewFileDeliverer(ctx, "routing", &appConfig)
+	//if err != nil {
+	//	return nil, err
+	//}
+	//if appConfig.RoutingConnection != nil {
+	//	routingAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "routing", &appConfig)
+	//	if err != nil {
+	//		logger.Error("failed to connect to router deliverer target", "error", err.Error())
+	//	} else {
+	//		postprocessing.RegisterTarget("routing", routingAzureDeliverer)
+	//		health.Register(routingAzureDeliverer)
+	//	}
+	//} else {
+	//	postprocessing.RegisterTarget("routing", routingFileDeliverer)
+	//	health.Register(routingFileDeliverer)
+	//}
 
 	uploadInfoHandler, err := GetUploadInfoHandler(&appConfig)
 	if err != nil {
@@ -129,7 +128,7 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	err = InitReporters(appConfig)
 
 	// get and initialize tusd hook handlers
-	hookHandler, err := GetHookHandler(appConfig)
+	hookHandler, err := GetHookHandler(context.TODO(), appConfig)
 	if err != nil {
 		logger.Error("error configuring tusd handler: ", "error", err)
 		return nil, err

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -56,10 +56,11 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 	if appConfig.AzureConnection != nil {
 		dexAzureDeliverer, err := postprocessing.NewAzureDeliverer(ctx, "dex", &appConfig)
 		if err != nil {
-			return nil, err
+			logger.Error("failed to connect to dex deliverer target", err.Error())
+		} else {
+			postprocessing.RegisterTarget("dex", dexAzureDeliverer)
+			health.Register(dexAzureDeliverer)
 		}
-		postprocessing.RegisterTarget("dex", dexAzureDeliverer)
-		health.Register(dexAzureDeliverer)
 	} else {
 		postprocessing.RegisterTarget("dex", dexFileDeliverer)
 		health.Register(dexFileDeliverer)

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -148,24 +148,24 @@ func GetAzureContainerConfig(target string) (*AzureContainerConfig, error) {
 	}
 }
 
-func LocalStoreConfig(target string) (*LocalStorageConfig, error) {
-	fromPath := os.DirFS(LoadedConfig.LocalFolderUploadsTus + "/" + LoadedConfig.TusUploadPrefix)
+func LocalStoreConfig(target string, appConfig *AppConfig) (*LocalStorageConfig, error) {
+	fromPath := os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix)
 
 	switch target {
 	case "dex":
 		return &LocalStorageConfig{
 			FromPath: fromPath,
-			ToPath:   LoadedConfig.LocalDEXFolder,
+			ToPath:   appConfig.LocalDEXFolder,
 		}, nil
 	case "edav":
 		return &LocalStorageConfig{
 			FromPath: fromPath,
-			ToPath:   LoadedConfig.LocalEDAVFolder,
+			ToPath:   appConfig.LocalEDAVFolder,
 		}, nil
 	case "routing":
 		return &LocalStorageConfig{
 			FromPath: fromPath,
-			ToPath:   LoadedConfig.LocalRoutingFolder,
+			ToPath:   appConfig.LocalRoutingFolder,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported local target %s", target)

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -38,11 +38,17 @@ type Deliverer interface {
 	Deliver(ctx context.Context, tuid string, metadata map[string]string) error
 }
 
-func NewFileDeliverer(ctx context.Context, target string) (*FileDeliverer, error) {
+func NewFileDeliverer(_ context.Context, target string) (*FileDeliverer, error) {
 	localConfig, err := appconfig.LocalStoreConfig(target)
 	if err != nil {
 		return nil, err
 	}
+
+	_, err = os.Stat(localConfig.ToPath)
+	if err != nil {
+		os.Mkdir(localConfig.ToPath, 0755)
+	}
+
 	return &FileDeliverer{
 		LocalStorageConfig: *localConfig,
 		Target:             target,

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -44,11 +44,6 @@ func NewFileDeliverer(_ context.Context, target string, appConfig *appconfig.App
 		return nil, err
 	}
 
-	_, err = os.Stat(localConfig.ToPath)
-	if err != nil {
-		os.Mkdir(localConfig.ToPath, 0755)
-	}
-
 	return &FileDeliverer{
 		LocalStorageConfig: *localConfig,
 		Target:             target,

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -56,7 +56,7 @@ func NewFileDeliverer(_ context.Context, target string) (*FileDeliverer, error) 
 }
 
 func NewAzureDeliverer(ctx context.Context, target string, appConfig *appconfig.AppConfig) (*AzureDeliverer, error) {
-	config, err := appconfig.AzureStoreConfig(target)
+	config, err := appconfig.GetAzureContainerConfig(target)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func NewAzureDeliverer(ctx context.Context, target string, appConfig *appconfig.
 	if err != nil {
 		return nil, err
 	}
-	checkpointContainerClient, err := storeaz.NewContainerClient(*config, config.ContainerName)
+	checkpointContainerClient, err := storeaz.NewContainerClient(config.AzureStorageConfig, config.ContainerName)
 	if err != nil {
 		return nil, err
 	}

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -38,8 +38,8 @@ type Deliverer interface {
 	Deliver(ctx context.Context, tuid string, metadata map[string]string) error
 }
 
-func NewFileDeliverer(_ context.Context, target string) (*FileDeliverer, error) {
-	localConfig, err := appconfig.LocalStoreConfig(target)
+func NewFileDeliverer(_ context.Context, target string, appConfig *appconfig.AppConfig) (*FileDeliverer, error) {
+	localConfig, err := appconfig.LocalStoreConfig(target, appConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/models"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/storeaz"
@@ -35,6 +36,7 @@ func RegisterTarget(name string, d Deliverer) {
 }
 
 type Deliverer interface {
+	health.Checkable
 	Deliver(ctx context.Context, tuid string, metadata map[string]string) error
 }
 

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -205,6 +205,7 @@ func (ad *AzureDeliverer) Deliver(ctx context.Context, tuid string, manifest map
 
 func (ad *AzureDeliverer) Health(ctx context.Context) (rsp models.ServiceHealthResp) {
 	rsp.Service = "Azure deliver target " + ad.Target
+	rsp.Status = models.STATUS_UP
 
 	if ad.ToContainerClient == nil {
 		// Running in azure, but deliverer not set up.

--- a/upload-server/internal/storeaz/azblobclientcheck.go
+++ b/upload-server/internal/storeaz/azblobclientcheck.go
@@ -25,6 +25,8 @@ func NewAzureHealthCheck(conf *azurestore.AzConfig) (*AzureBlobHealthCheck, erro
 	}, nil
 }
 
+// TODO Health check that uses service principle.  Maybe don't need this if lower function handles it.
+
 func (c *AzureBlobHealthCheck) Health(ctx context.Context) models.ServiceHealthResp {
 	return checkAzBlobClient(tusPrefix, c.client)
 }

--- a/upload-server/internal/storeaz/azblobclientnew.go
+++ b/upload-server/internal/storeaz/azblobclientnew.go
@@ -97,6 +97,8 @@ func newAzBlobClient(azStorageName, azStorageKey, azContainerEndpoint string) (*
 	return client, nil
 } // .newAzBlobClient
 
+// TODO helper for getting credential via service principle or key
+
 func canUseStorageKey(conf appconfig.AzureStorageConfig) bool {
 	return conf.StorageKey != ""
 }

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -320,7 +320,7 @@ func TestMain(m *testing.M) {
 		LocalReportsFolder:    "test/reports",
 		LocalDEXFolder:        "test/dex",
 		LocalEDAVFolder:       "test/edav",
-		LocalROUTINGFolder:    "test/routing",
+		LocalRoutingFolder:    "test/routing",
 		TusdHandlerBasePath:   "/files/",
 	}
 


### PR DESCRIPTION
Idea here is to relate registration of file deliverers and registration of health checks on the respected delivery storage targets.  Eg: Registering an EDAV deliverer should also register a health check on the EDAV storage (file or azure).  