### PR TITLE
UPLOAD-1388: Default to tusd in-memory locker, if Redis is not available at startup

### DIFF
--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -50,17 +50,17 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 		var err error
 		locker, err = redislocker.New(appConfig.TusRedisLockURI, redislocker.WithLogger(logger))
 		if err != nil {
-			logger.Error("error configuring redis locker", "error", err)
-			return nil, err
+			logger.Error("error configuring redis locker, using tusd in-memory locker instead", "error", err)
+			// return nil, err
 		}
 		// redislocker health check
 		redisLockerHealth, err := redislockerhealth.New(appConfig.TusRedisLockURI)
 		if err != nil {
-			logger.Error("error configuring redis locker health check: ", "error", err)
-			return nil, err
+			logger.Error("error configuring redis locker health check, ommiting this check", "error", err)
+		} else {
+			health.Register(redisLockerHealth)
 		}
 
-		health.Register(redisLockerHealth)
 	}
 
 	// initialize event reporter

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -50,17 +50,16 @@ func Serve(appConfig appconfig.AppConfig) (http.Handler, error) {
 		var err error
 		locker, err = redislocker.New(appConfig.TusRedisLockURI, redislocker.WithLogger(logger))
 		if err != nil {
-			logger.Error("error configuring redis locker, using tusd in-memory locker instead", "error", err)
-			// return nil, err
+			logger.Error("failed to configure Redis locker, defaulting to in-memory locker", "error", err)
 		}
-		// redislocker health check
+
+		// configure redislocker health check
 		redisLockerHealth, err := redislockerhealth.New(appConfig.TusRedisLockURI)
 		if err != nil {
-			logger.Error("error configuring redis locker health check, ommiting this check", "error", err)
+			logger.Error("failed to configure Redis locker health check, skipping check", "error", err)
 		} else {
 			health.Register(redisLockerHealth)
 		}
-
 	}
 
 	// initialize event reporter


### PR DESCRIPTION
Jira: UPLOAD-1388

#### Summary

This changes the startup behavior to use the tusd in-memory locker, if the Redis service is not available. Currently, the server startup will fail.

The Redis health check configuration will be skipped, if Redis is unavailable as well.

The error messaging is also improved.