### PR TITLE
ABCs - Metadata Smoke Test Additions

### DIFF
--- a/tests/smoke/kotlin/src/test/kotlin/Health.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/Health.kt
@@ -22,7 +22,11 @@ class Health {
 
         Assert.assertNotNull(healthCheck)
         Assert.assertEquals(healthCheck.status, "UP")
-        Assert.assertEquals(healthCheck.services.size, expectedDependentServices.size, "Unexpected number of dependent services: ${healthCheck.services}")
+
+        Assert.assertEquals(
+            healthCheck.services.size,
+            expectedDependentServices.size, "Unexpected number of dependent services: ${healthCheck.services}"
+        )
 
         healthCheck.services.forEach {
             Assert.assertTrue(expectedDependentServices.contains(it.service))

--- a/tests/smoke/kotlin/src/test/kotlin/Health.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/Health.kt
@@ -22,11 +22,7 @@ class Health {
 
         Assert.assertNotNull(healthCheck)
         Assert.assertEquals(healthCheck.status, "UP")
-
-        Assert.assertEquals(
-            healthCheck.services.size,
-            expectedDependentServices.size, "Unexpected number of dependent services: ${healthCheck.services}"
-        )
+        Assert.assertEquals(healthCheck.services.size, expectedDependentServices.size, "Unexpected number of dependent services: ${healthCheck.services}")
 
         healthCheck.services.forEach {
             Assert.assertTrue(expectedDependentServices.contains(it.service))

--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
@@ -287,5 +287,32 @@
     "patient_sex": "M",
     "instrument": "test instrument",
     "variant_caller": "test variant caller"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "abcs",
+    "data_stream_route": "csv",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "CA",
+    "data_producer_id": "CA-ABCs",
+    "sender_id": "ca-abcs"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "abcs",
+    "data_stream_route": "csv",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "blah",
+    "data_producer_id": "ca-abcs",
+    "sender_id": "CA-ABCs"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "abcs",
+    "data_stream_route": "csv",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "CA",
+    "data_producer_id": "CA-ABCs",
+    "sender_id": "@1234"
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
@@ -156,5 +156,13 @@
     "patient_sex": "M",
     "instrument": "test instrument",
     "variant_caller": "test variant caller"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "abcs",
+    "data_stream_route": "csv",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "CA",
+    "data_producer_id": "CA-ABCs"
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -141,20 +141,29 @@
     "meta_ext_filestatus": "test-file-status"
   },
   {
-  "version": "2.0",
-  "data_stream_id": "ed3n",
-  "data_stream_route": "other",
-  "received_filename": "dex-smoke-test",
-  "jurisdiction": "MA",
-  "data_producer_id": "MA-NBS",
-  "sender_id": "ED3N-App",
-  "nbs_data_type": "MOLECULAR",
-  "specimen_id": "blood test specimen",
-  "patient_id": "",
-  "patient_race": "White",
-  "patient_ethnicity": "Hispanic",
-  "patient_sex": "M",
-  "instrument": "test instrument",
-  "variant_caller": "test variant caller"
-}
+    "version": "2.0",
+    "data_stream_id": "ed3n",
+    "data_stream_route": "other",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "MA",
+    "data_producer_id": "MA-NBS",
+    "sender_id": "ED3N-App",
+    "nbs_data_type": "MOLECULAR",
+    "specimen_id": "blood test specimen",
+    "patient_id": "",
+    "patient_race": "White",
+    "patient_ethnicity": "Hispanic",
+    "patient_sex": "M",
+    "instrument": "test instrument",
+    "variant_caller": "test variant caller"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "abcs",
+    "data_stream_route": "csv",
+    "received_filename": "dex-smoke-test",
+    "jurisdiction": "CA",
+    "data_producer_id": "CA-ABCs",
+    "sender_id": "CA-ABCs"
+  }
 ]


### PR DESCRIPTION
1. Happy path file is updated with ABCs sender manifest valid fields and allowed values.

2.  Invalid Value error path file is updated with ABCs sender manifest fields, with at least one field containing a value that is not allowed.

3. Invalid Field Exclusion error path file is updated with ABCs sender manifest fields, with at least one required field missing.