### PR TITLE
Add handling for SIGTERM signal for graceful process termination

### DIFF
--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -3,15 +3,17 @@ package main
 import (
 	"context"
 	"errors"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"runtime/debug"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 
 	"github.com/cdcgov/data-exchange-upload/upload-server/cmd/cli"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
@@ -132,7 +134,7 @@ func main() {
 	// 	Block for Exit, server above is on goroutine
 	// ------------------------------------------------------------------
 	sigint := make(chan os.Signal, 1)
-	signal.Notify(sigint, os.Interrupt)
+	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 	<-sigint
 	cancelFunc()
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This adds the handling of the `SIGTERM` signal, so that the server can gracefully shutdown when the OS sends a `SIGTERM` broadcast to all processes during a shutdown.

## Testing notes
Prior to adding this, the CTRL-c interrupt was handled, but the SIGTERM via a process kill command was not.

From local testing:

- Killing the process during a tusd file upload:
  - Immediately stops the process and exits OK.
  - Has a partial file size in tus-prefix/ at the point it was stopped.
  - After starting up another server, continuing the upload via the client works OK.
 
- Killing the process during the file delivery:
  - The workers successfully copy the full files out to destinations before exiting.
  - NOTE: Depending on the file size and the OS's grace period timing (before broadcasting the final SIGKILL), this still might not leave enough time for all copies to complete.