### PR TITLE
PulseNet - Metadata Smoke Test Additions

### DIFF
--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
@@ -314,5 +314,23 @@
     "jurisdiction": "CA",
     "data_producer_id": "CA-ABCs",
     "sender_id": "@1234"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "pulsenet",
+    "data_stream_route": "localsequencefile",
+    "received_filename": "dex-smoke-test",
+    "sender_id" : "pulsenet-app",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "pulsenet",
+    "data_stream_route": "localsequencefile",
+    "received_filename": "dex-smoke-test",
+    "sender_id" : "blah",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
@@ -164,5 +164,13 @@
     "received_filename": "dex-smoke-test",
     "jurisdiction": "CA",
     "data_producer_id": "CA-ABCs"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "pulsenet",
+    "data_stream_route": "localsequencefile",
+    "received_filename": "dex-smoke-test",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -165,5 +165,14 @@
     "jurisdiction": "CA",
     "data_producer_id": "CA-ABCs",
     "sender_id": "CA-ABCs"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "pulsenet",
+    "data_stream_route": "localsequencefile",
+    "received_filename": "dex-smoke-test",
+    "sender_id" : "PulseNet-App",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
   }
 ]


### PR DESCRIPTION
1. Happy path file is updated with PulseNet sender manifest valid fields and allowed values

2. Invalid Value error path file is updated with PulseNet sender manifest fields, with at least one field containing a value that is not allowed

3. Invalid Field Exclusion error path file is updated with PulseNet sender manifest fields, with at least one required field missing