### PR TITLE
Allow sub templates in the simulator

### DIFF
--- a/tests/bad-uploader/examples/test.hl7
+++ b/tests/bad-uploader/examples/test.hl7
@@ -1,0 +1,11 @@
+{{- define "header"}}
+MSH|^~\&|HL7|CG3_SICU|CE_CENTRAL|GH_CSF|20251014154001||ORU^R01|{{RandomString 14}}|P|2.3||||||UNICODE UTF-8
+PID|||10002^^^A^MR||RAPID^^|^^|||||^^^^^^^||||||||||||||||||
+PV1||E|G52008|||||||||||||||||||||||||||||||||||||||||
+{{- end}}
+{{- define "obr"}}
+OBR|{{.Index}}||||||20251014154001||||||||||||||||||||^^^^|||||||||
+{{- end}}
+{{- define "obx"}}
+OBX|{{.Index}}|ST|HR||68|/min|||||R
+{{- end}}

--- a/tests/bad-uploader/examples/test.json
+++ b/tests/bad-uploader/examples/test.json
@@ -1,0 +1,20 @@
+{
+    "Chunk": 5,
+    "Manifest": {
+		"meta_destination_id": "dextesting",
+		"meta_ext_event":      "testevent1",
+		"filename":            "test"
+	},
+	"templatefile": "examples/test.hl7",
+	"templates": [
+		{
+			"name": "header",
+			"repetitions": 1
+		},
+		{
+			"name": "obx",
+			"repetitions": 12
+		}
+	],
+	"repetitions": 2
+}

--- a/tests/bad-uploader/go.mod
+++ b/tests/bad-uploader/go.mod
@@ -2,7 +2,7 @@ module github.com/cdcgov/bad-uploader
 
 go 1.22.1
 
-replace github.com/eventials/go-tus => /home/whytheplatypus/Development/go-tus
+replace github.com/eventials/go-tus => github.com/whytheplatypus/go-tus v0.0.0-20240709121510-b5e0bef51f72
 
 require (
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571

--- a/tests/bad-uploader/go.mod
+++ b/tests/bad-uploader/go.mod
@@ -2,7 +2,7 @@ module github.com/cdcgov/bad-uploader
 
 go 1.22.1
 
-replace github.com/eventials/go-tus => github.com/whytheplatypus/go-tus v0.0.0-20240703123832-233d6aa3475d
+replace github.com/eventials/go-tus => /home/whytheplatypus/Development/go-tus
 
 require (
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571

--- a/tests/bad-uploader/go.sum
+++ b/tests/bad-uploader/go.sum
@@ -86,6 +86,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tus/tusd v1.1.0 h1:y2oBFGeOyqlGgyqD0CloH8FuBrjDk0Tq1IQWvAZnyG8=
 github.com/tus/tusd v1.1.0/go.mod h1:3DWPOdeCnjBwKtv98y5dSws3itPqfce5TVa0s59LRiA=
 github.com/vimeo/go-util v1.2.0/go.mod h1:s13SMDTSO7AjH1nbgp707mfN5JFIWUFDU5MDDuRRtKs=
+github.com/whytheplatypus/go-tus v0.0.0-20240709121510-b5e0bef51f72 h1:vHLyT0ESH5hhmXUxKDZby6GK1/TSNHb7tLpB56EFyjk=
+github.com/whytheplatypus/go-tus v0.0.0-20240709121510-b5e0bef51f72/go.mod h1:XYuK1S5+kS6FGhlIUFuZFPvWiSrOIoLk6+ro33Xce3Y=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/tests/bad-uploader/go.sum
+++ b/tests/bad-uploader/go.sum
@@ -86,8 +86,6 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tus/tusd v1.1.0 h1:y2oBFGeOyqlGgyqD0CloH8FuBrjDk0Tq1IQWvAZnyG8=
 github.com/tus/tusd v1.1.0/go.mod h1:3DWPOdeCnjBwKtv98y5dSws3itPqfce5TVa0s59LRiA=
 github.com/vimeo/go-util v1.2.0/go.mod h1:s13SMDTSO7AjH1nbgp707mfN5JFIWUFDU5MDDuRRtKs=
-github.com/whytheplatypus/go-tus v0.0.0-20240703123832-233d6aa3475d h1:RxIpLOIOkRKKuwSWR40ehNfl+E+4BcOl6a2zTgUHx6E=
-github.com/whytheplatypus/go-tus v0.0.0-20240703123832-233d6aa3475d/go.mod h1:XYuK1S5+kS6FGhlIUFuZFPvWiSrOIoLk6+ro33Xce3Y=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -340,7 +339,7 @@ func runTest(t TestCase, conf *config) error {
 	}
 	log.Println(uploader.Url())
 
-	uploader.SetUrl("https://apidev.cdc.gov/upload/files/" + path.Base(uploader.Url()))
+	//uploader.SetUrl("https://apidev.cdc.gov/upload/files/" + path.Base(uploader.Url()))
 
 	slog.Debug("UploadID", "upload_id", uploader.Url())
 	c := make(chan tus.Upload)

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -38,12 +38,13 @@ var (
 	patchURL    string
 
 	manifest = JSONVar{
+		"version":           "2.0",
 		"data_stream_id":    "dextesting",
 		"data_stream_route": "testevent1",
 		"received_filename": "test",
 		"sender_id":         "dex simulation harness",
 		"data_producer_id":  "dex simulation harness",
-		"juristiction":      "test",
+		"jurisdiction":      "test",
 	}
 
 	testcase TestCase
@@ -345,7 +346,11 @@ func runTest(t TestCase, conf *config) error {
 	}
 
 	if patchURL != "" {
-		uploader.SetUrl(path.Join(patchURL, path.Base(uploader.Url())))
+		p, err := neturl.JoinPath(patchURL, path.Base(uploader.Url()))
+		if err != nil {
+			return err
+		}
+		uploader.SetUrl(p)
 	}
 
 	slog.Debug("UploadID", "upload_id", uploader.Url())

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -38,9 +38,12 @@ var (
 	patchURL    string
 
 	manifest = JSONVar{
-		"meta_destination_id": "dextesting",
-		"meta_ext_event":      "testevent1",
-		"filename":            "test",
+		"data_stream_id":    "dextesting",
+		"data_stream_route": "testevent1",
+		"received_filename": "test",
+		"sender_id":         "dex simulation harness",
+		"data_producer_id":  "dex simulation harness",
+		"juristiction":      "test",
 	}
 
 	testcase TestCase

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -66,6 +66,7 @@ func (f *JSONVar) Set(s string) error {
 }
 
 type SubTemplate struct {
+	Name        string
 	Repetitions int
 	Args        map[string]any
 }
@@ -75,7 +76,7 @@ type TestCase struct {
 	Size         float64
 	Manifest     map[string]string
 	TemplateFile string
-	Templates    map[string]SubTemplate
+	Templates    []SubTemplate
 	Repetitions  int
 }
 

--- a/tests/bad-uploader/template.go
+++ b/tests/bad-uploader/template.go
@@ -59,7 +59,6 @@ func (tg *TemplateGenerator) next() (err error) {
 		templates := tg.Templates
 		for _, t := range templates {
 			slog.Debug("writing template")
-			// ok we know this generates the whole template, so it can be a memory issue
 			if t.Args == nil {
 				t.Args = map[string]any{}
 			}

--- a/tests/bad-uploader/template.go
+++ b/tests/bad-uploader/template.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"log"
 	"log/slog"
@@ -96,7 +97,7 @@ func (tg *TemplateGenerator) Read(p []byte) (int, error) {
 	//todo only swallow unexpected eof errors
 	slog.Debug("read template")
 	_, peakErr := tg.r.Peek(len(p))
-	if err == io.ErrUnexpectedEOF || peakErr == io.EOF {
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(peakErr, io.EOF) {
 		if tg.Repeats < 1 {
 			return n, io.EOF
 		}

--- a/tests/bad-uploader/tests/test copy.json
+++ b/tests/bad-uploader/tests/test copy.json
@@ -1,0 +1,9 @@
+{
+    "Chunk": 0.5,
+    "Size": 10,
+    "Manifest": {
+		"meta_destination_id": "dextesting",
+		"meta_ext_event":      "testevent1",
+		"filename":            "test"
+	}
+}


### PR DESCRIPTION
This allows the construction of very large structured files (like a huge hl7v2 file) without a massive impact on system resources.