### PR TITLE
Quickfix/deliver stream

### DIFF
--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -181,6 +181,7 @@ func (ad *AzureDeliverer) Deliver(ctx context.Context, tuid string, manifest map
 
 	destBlobClient := ad.ToContainerClient.NewBlobClient(blobName)
 	s, err := srcBlobClient.DownloadStream(ctx, nil)
+	defer s.Body.Close()
 	if err != nil {
 		return err
 	}

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -194,29 +194,6 @@ func (ad *AzureDeliverer) Deliver(ctx context.Context, tuid string, manifest map
 
 	logger.Info("successful copy from", "src", srcBlobClient.URL(), "to dest", destBlobClient.URL())
 
-	//resp, err := destBlobClient.StartCopyFromURL(ctx, srcBlobClient.URL(), nil)
-	//if err != nil {
-	//	return err
-	//}
-	//
-	//status := *resp.CopyStatus
-	//var statusDescription string
-	//for status == blob.CopyStatusTypePending {
-	//	getPropResp, err := destBlobClient.GetProperties(ctx, nil)
-	//	if err != nil {
-	//		return err
-	//	}
-	//	status = *getPropResp.CopyStatus
-	//	statusDescription = *getPropResp.CopyStatusDescription
-	//	logger.Info("Copy progress", "status", fmt.Sprintf("%s", status))
-	//}
-	//
-	//if status != blob.CopyStatusTypeSuccess {
-	//	return fmt.Errorf("copy to target %s unsuccessful with status %s and description %s", ad.Target, status, statusDescription)
-	//}
-	//
-	//logger.Info("Copy from", "src", srcBlobClient.URL(), "to dest", destBlobClient.URL(), "status", status)
-
 	return nil
 }
 


### PR DESCRIPTION
Refactor azure copy operation to use streams instead of async scheduler.  This is necessary because Azure is unable to perform a blob copy on a client's behalf if the source or destination storage accounts are in private vnets in their current configurations.  See this article for more details: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-storage/blobs/connectivity/copy-blobs-between-storage-accounts-network-restriction#copy-blobs-between-storage-accounts-in-a-hub-spoke-architecture-using-private-endpoints

This patch uses workaround 4 specified in the article.  This is the same workaround that the upload processor (C# app) uses.  In the future,  we may want to consider other configurations so the router can take advantage of scheduled copying.