### PR TITLE
utc for global timestamp and better format for report start and end time

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -403,7 +403,7 @@ func WithTimestamp(event handler.HookEvent, resp hooks.HookResponse) (hooks.Hook
 		return resp, errors.New("no Upload ID defined")
 	}
 
-	timestamp := time.Now().Format(time.RFC3339)
+	timestamp := time.Now().UTC().Format(time.RFC3339)
 	logger.Info("adding global timestamp", "timestamp", timestamp)
 
 	manifest := event.Upload.MetaData

--- a/upload-server/pkg/reports/builder.go
+++ b/upload-server/pkg/reports/builder.go
@@ -185,8 +185,8 @@ func (b *ReportBuilder[T]) Build() *Report {
 				Service:          "UPLOAD API",
 				Version:          fmt.Sprintf("%s_%s", version.LatestReleaseVersion, version.GitShortSha),
 				Status:           b.Status,
-				StartProcessTime: b.StartTime.String(),
-				EndProcessTime:   b.EndTime.String(),
+				StartProcessTime: b.StartTime.Format(time.RFC3339),
+				EndProcessTime:   b.EndTime.Format(time.RFC3339),
 			},
 			Content: b.Content,
 		}


### PR DESCRIPTION
This PR assures that UTC is used for timestamps