### PR TITLE
Update ed3n config w/ uploaded_by field

### DIFF
--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_invalid_value.json
@@ -235,7 +235,8 @@
     "patient_ethnicity": "Hispanic",
     "patient_sex": "M",
     "instrument": "test instrument",
-    "variant_caller": "test variant caller"
+    "variant_caller": "test variant caller",
+    "uploaded_by": "jdoe"
   },
   {
     "version": "2.0",
@@ -252,7 +253,8 @@
     "patient_ethnicity": "Hispanic",
     "patient_sex": "M",
     "instrument": "test instrument",
-    "variant_caller": "test variant caller"
+    "variant_caller": "test variant caller",
+    "uploaded_by": "jdoe"
   },
   {
     "version": "2.0",
@@ -269,7 +271,8 @@
     "patient_ethnicity": "Hispanic",
     "patient_sex": "M",
     "instrument": "test instrument",
-    "variant_caller": "test variant caller"
+    "variant_caller": "test variant caller",
+    "uploaded_by": "jdoe"
   },
   {
     "version": "2.0",
@@ -286,7 +289,8 @@
     "patient_ethnicity": "Not Hispanic",
     "patient_sex": "M",
     "instrument": "test instrument",
-    "variant_caller": "test variant caller"
+    "variant_caller": "test variant caller",
+    "uploaded_by": "jdoe"
   },
   {
     "version": "2.0",

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -155,7 +155,8 @@
     "patient_ethnicity": "Hispanic",
     "patient_sex": "M",
     "instrument": "test instrument",
-    "variant_caller": "test variant caller"
+    "variant_caller": "test variant caller",
+    "uploaded_by": "jdoe"
   },
   {
     "version": "2.0",

--- a/upload-configs/v2/ed3n-other.json
+++ b/upload-configs/v2/ed3n-other.json
@@ -108,6 +108,12 @@
             "required": false,
             "allowed_values": null,
             "description": "The reagent kit used for the sequencing"
+        },
+        {
+            "field_name": "uploaded_by",
+            "required": true,
+            "allowed_values": null,
+            "description": "The identity of the uploader"
         }
       ]
     },


### PR DESCRIPTION
### Summary:

- Adds an `uploaded_by` required text field to the ed3n-other config.
- Adds the `uploaded_by` field to TESTS json.