### PR TITLE
Upload 1528/upload id in error response

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -219,7 +219,7 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent, resp hooks.
 				StatusCode: http.StatusBadRequest,
 				Body:       err.Error(),
 			})
-			return resp, nil
+			return resp, nil // Should return err here?
 		}
 		return resp, err
 	}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -233,7 +233,7 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent, resp hooks.
 				StatusCode: http.StatusBadRequest,
 				Body:       string(b),
 			})
-			return resp, nil // Should return err here?
+			return resp, nil
 		}
 		return resp, err
 	}

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -49,6 +49,11 @@ var registeredVersions = map[string]func(handler.MetaData) (validation.ConfigLoc
 	"2.0": v2.NewFromManifest,
 }
 
+type PreCreateResponse struct {
+	UploadId         string   `json:"upload_id"`
+	ValidationErrors []string `json:"validation_errors"`
+}
+
 var Cache *ConfigCache
 
 type ConfigCache struct {
@@ -215,9 +220,18 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent, resp hooks.
 
 		if errors.Is(err, validation.ErrFailure) {
 			resp.RejectUpload = true
+
+			respBody := PreCreateResponse{
+				UploadId:         tuid,
+				ValidationErrors: strings.Split(err.Error(), "\n"),
+			}
+			b, err := json.Marshal(respBody)
+			if err != nil {
+				return resp, err
+			}
 			resp.HTTPResponse = resp.HTTPResponse.MergeWith(handler.HTTPResponse{
 				StatusCode: http.StatusBadRequest,
-				Body:       err.Error(),
+				Body:       string(b),
 			})
 			return resp, nil // Should return err here?
 		}

--- a/upload-server/pkg/hooks/prebuilt.go
+++ b/upload-server/pkg/hooks/prebuilt.go
@@ -1,7 +1,6 @@
 package hooks
 
 import (
-	"fmt"
 	"github.com/tus/tusd/v2/pkg/handler"
 	tusHooks "github.com/tus/tusd/v2/pkg/hooks"
 )
@@ -26,18 +25,6 @@ func (ph *PrebuiltHook) InvokeHook(req tusHooks.HookRequest) (res tusHooks.HookR
 	resp := tusHooks.HookResponse{}
 	for _, hf := range hookFuncs {
 		resp, err = hf(req.Event, resp)
-
-		// Maybe should add upload ID for all response bodies.  Not just rejected ones.  Probs unnecessary though.
-		if resp.RejectUpload {
-			tuid := req.Event.Upload.ID
-			if tuid == "" {
-				tuid = resp.ChangeFileInfo.ID
-			}
-
-			resp.HTTPResponse = resp.HTTPResponse.MergeWith(handler.HTTPResponse{
-				Body: fmt.Sprintf("error for upload ID %s. %s", tuid, resp.HTTPResponse.Body),
-			})
-		}
 
 		// Return early if we got an error.
 		if err != nil {


### PR DESCRIPTION
The purpose of this patch is to provide tus clients with the custom upload ID that the server creates when there are validation errors.  This is to allow these clients to gather PS API report information on that upload attempt more easily.

My initial approach to this was to simply concatenate the upload ID to the validation error message within the response body.  I then thought providing a structured json body with fields for the upload ID and validation errors was better because clients can parse this information out more easily.