### PR TITLE
Quickfix/slf4j logging smoke test

### DIFF
--- a/tests/smoke/kotlin/README.md
+++ b/tests/smoke/kotlin/README.md
@@ -64,8 +64,8 @@ library to read and filter JSON manifests based on criteria specified through sy
 To filter specific key-value pairs in the JSON manifests, use the `manifestFilter` system property.
 Here are the example commands to run the tests with manifest filters:
 
-`gradle test -PmanifestFilter='meta_destination_id=ndlp;meta_ext_source=IZGW'`
-`gradle test -PmanifestFilter='jurisdiction=AKA,CA;data_stream_route=csv,other;sender_id=CA-ABCs,IZGW'`
+`gradle test -PmanifestFilter='meta_destination_id=ndlp&meta_ext_source=IZGW'`
+`gradle test -PmanifestFilter='jurisdiction=AKA,CA;data_stream_route=csv,other&sender_id=CA-ABCs,IZGW'`
 
 We can run tests for specified manifest in a single command line argument.
 

--- a/tests/smoke/kotlin/build.gradle.kts
+++ b/tests/smoke/kotlin/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.9")
     testImplementation("io.rest-assured:rest-assured:5.4.0")
     testImplementation("joda-time:joda-time:2.12.7")
+    testImplementation("org.slf4j:slf4j-simple:1.6.1")
 }
 
 tasks.test {

--- a/tests/smoke/kotlin/src/test/kotlin/MetadataVerify.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/MetadataVerify.kt
@@ -34,7 +34,7 @@ class MetadataVerify {
         dataProvider = "invalidManifestRequiredFieldsProvider",
         dataProviderClass = DataProvider::class,
         expectedExceptions = [ProtocolException::class],
-        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*field .* was missing"
+        expectedExceptionsMessageRegExp = "unexpected status code \\(400\\).*field .* was missing.*"
     )
     fun shouldReturnErrorWhenMissingRequiredField(manifest: Map<String, String>) {
         uploadClient.uploadFile(testFile, manifest)

--- a/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
@@ -21,6 +21,7 @@ class DataProvider {
         @DataProvider(name = "validManifestAllProvider")
         fun validManifestAllProvider(): Array<Array<Map<String, String>>> {
             val validManifests = arrayOf("valid_manifests_v1.json", "valid_manifests_v2.json")
+            logger<util.DataProvider>().info("Filtering all valid manifests")
             return loadAndFilterManifests(validManifests)
         }
 
@@ -28,6 +29,7 @@ class DataProvider {
         @DataProvider(name = "validManifestV1Provider")
         fun validManifestV1Provider(): Array<Array<Map<String, String>>> {
             val validManifests = arrayOf("valid_manifests_v1.json")
+            logger<util.DataProvider>().info("Filtering V1 valid manifests")
             return loadAndFilterManifests(validManifests)
         }
 
@@ -35,6 +37,7 @@ class DataProvider {
         @DataProvider(name = "invalidManifestRequiredFieldsProvider")
         fun invalidManifestRequiredFieldsProvider(): Array<Array<Map<String, String>>> {
             val invalidManifests = arrayOf("invalid_manifests_required_fields.json")
+            logger<util.DataProvider>().info("Filtering invalid required field manifests")
             return loadAndFilterManifests(invalidManifests)
         }
 
@@ -42,6 +45,7 @@ class DataProvider {
         @DataProvider(name = "invalidManifestInvalidValueProvider")
         fun invalidManifestInvalidValueProvider(): Array<Array<Map<String, String>>> {
             val invalidManifests = arrayOf("invalid_manifests_invalid_value.json")
+            logger<util.DataProvider>().info("Filtering invalid value manifests")
             return loadAndFilterManifests(invalidManifests)
         }
 
@@ -70,14 +74,14 @@ class DataProvider {
 
                 if (manifestFilters.isNotEmpty()) {
                     val filtered = filterManifestJsons(manifestJsons, manifestFilters)
-                    println("Filtered manifests: $filtered")
+                    logger<util.DataProvider>().debug("Filtered manifests: {}", filtered)
                     manifests.addAll(filtered)
                 } else {
                     manifests.addAll(manifestJsons)
                 }
             }
-            println("Total number of manifests: $totalManifests, Number of filtered manifests: ${manifests.size}")
-            println("Final Manifest: $manifests")
+            logger<util.DataProvider>().info("Total number of manifests: $totalManifests, Number of filtered manifests: ${manifests.size}")
+            logger<util.DataProvider>().info("Final Manifest: $manifests")
             return manifests.map { arrayOf(it) }.toTypedArray()
         }
 

--- a/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
@@ -71,7 +71,7 @@ class DataProvider {
                 return toTypedMatrix(manifests)
             }
 
-            val fields = manifestFilter.split(";")
+            val fields = manifestFilter.split("&")
             val manifestFilters = mutableMapOf<String, List<String>>()
 
             for (field in fields) {

--- a/tests/smoke/kotlin/src/test/kotlin/util/Logging.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/Logging.kt
@@ -1,0 +1,11 @@
+package util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+inline fun <reified T> logger(): Logger {
+    return LoggerFactory.getLogger(T::class.java)
+}
+
+class Logging {
+}

--- a/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
+++ b/tests/smoke/kotlin/src/test/resources/invalid_manifests_required_fields.json
@@ -172,5 +172,13 @@
     "received_filename": "dex-smoke-test",
     "data_producer_id": "test-producer-id",
     "jurisdiction": "test-jurisdiction"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "dextesting",
+    "data_stream_route": "testevent1",
+    "received_filename": "dex-smoke-test",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -175,5 +175,14 @@
     "sender_id" : "PulseNet-App",
     "data_producer_id": "test-producer-id",
     "jurisdiction": "test-jurisdiction"
+  },
+  {
+    "version": "2.0",
+    "data_stream_id": "dextesting",
+    "data_stream_route": "testevent1",
+    "received_filename": "dex-smoke-test",
+    "sender_id" : "test sender",
+    "data_producer_id": "test-producer-id",
+    "jurisdiction": "test-jurisdiction"
   }
 ]


### PR DESCRIPTION
Adds slf4j logs and cleans up filtering log and code a bit.  Also adds valid v2 manifests for dextesting to enable smoke tests in CD pipeline.