### PR TITLE
add test config values for sender testing

### DIFF
--- a/upload-configs/v2/covid-all-monthly-vaccination-csv.json
+++ b/upload-configs/v2/covid-all-monthly-vaccination-csv.json
@@ -109,7 +109,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field is the identifier for the data producer."
 			},
@@ -211,7 +212,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_ext_entity"

--- a/upload-configs/v2/covid-bridge-vaccination-csv.json
+++ b/upload-configs/v2/covid-bridge-vaccination-csv.json
@@ -109,7 +109,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field is the identifier for the data producer."
 			},
@@ -211,7 +212,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_ext_entity"

--- a/upload-configs/v2/influenza-vaccination-csv.json
+++ b/upload-configs/v2/influenza-vaccination-csv.json
@@ -109,7 +109,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field is the identifier for the data producer."
 			},
@@ -211,7 +212,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_ext_entity"

--- a/upload-configs/v2/routine-immunization-other.json
+++ b/upload-configs/v2/routine-immunization-other.json
@@ -109,7 +109,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field is the identifier for the data producer."
 			},
@@ -211,7 +212,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_ext_entity"

--- a/upload-configs/v2/rsv-prevention-csv.json
+++ b/upload-configs/v2/rsv-prevention-csv.json
@@ -109,7 +109,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field is the identifier for the data producer."
 			},
@@ -211,7 +212,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
 				"compat_field_name": "meta_ext_entity"


### PR DESCRIPTION
## Updates

- Added test allowed value "XXA" to NDLP sender manifest configurations to be utilized for sender testing purposes
- Allowed values added to data_producer_id and jurisdiction allowed values list
- Configs updated: Covid Bridge Vaccination, Covid All Monthly Vaccination, RSV Prevention, Influenza Vaccination, and Routine Immunization