### PR TITLE
Upload 1580/route endpoint

### DIFF
--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -1,8 +1,17 @@
 package cli
 
-import "net/http"
+import (
+	"encoding/json"
+	"errors"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
+	"io"
+	"net/http"
+)
 
 type Router struct{}
+type RequestBody struct {
+	Target string `json:"target"`
+}
 
 func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
@@ -10,5 +19,24 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := r.PathValue("UploadID")
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		rw.WriteHeader(400)
+		return
+	}
+	var body RequestBody
+	err = json.Unmarshal(b, &body)
+	if err != nil {
+		rw.WriteHeader(400)
+		return
+	}
+
+	err = postprocessing.Deliver(r.Context(), id, nil, body.Target)
+	if err != nil && errors.Is(err, postprocessing.ErrBadTarget) {
+		rw.WriteHeader(400)
+		rw.Write([]byte(err.Error() + " " + body.Target))
+		return
+	}
+
 	rw.Write([]byte(id))
 }

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 	"io"
 	"net/http"
@@ -31,19 +32,38 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = postprocessing.Deliver(r.Context(), id, body.Target)
+	d, ok := postprocessing.GetTarget(body.Target)
+	if !ok {
+		rw.WriteHeader(400)
+		rw.Write([]byte("invalid target " + body.Target))
+		return
+	}
+	srcUrl, err := d.GetSrcUrl(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, postprocessing.ErrBadTarget) {
-			rw.WriteHeader(400)
-			rw.Write([]byte(err.Error() + " " + body.Target))
-			return
-		}
 		if errors.Is(err, postprocessing.ErrSrcFileNotExist) {
 			rw.WriteHeader(404)
 			rw.Write([]byte(err.Error()))
 			return
 		}
+	}
+	m, err := d.GetMetadata(r.Context(), id)
+	if err != nil {
+		rw.WriteHeader(500)
+		rw.Write([]byte(err.Error()))
+		return
+	}
 
+	e := &event.FileReady{
+		Event: event.Event{
+			Type: event.FileReadyEventType,
+		},
+		UploadId:          id,
+		DestinationTarget: body.Target,
+		Metadata:          m,
+		SrcUrl:            srcUrl,
+	}
+	err = event.FileReadyPublisher.Publish(r.Context(), e)
+	if err != nil {
 		// Unhandled error occurred
 		rw.WriteHeader(500)
 		rw.Write([]byte(err.Error()))

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -32,9 +32,21 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	err = postprocessing.Deliver(r.Context(), id, nil, body.Target)
-	if err != nil && errors.Is(err, postprocessing.ErrBadTarget) {
-		rw.WriteHeader(400)
-		rw.Write([]byte(err.Error() + " " + body.Target))
+	if err != nil {
+		if errors.Is(err, postprocessing.ErrBadTarget) {
+			rw.WriteHeader(400)
+			rw.Write([]byte(err.Error() + " " + body.Target))
+			return
+		}
+		if errors.Is(err, postprocessing.ErrSrcFileNotExist) {
+			rw.WriteHeader(404)
+			rw.Write([]byte(err.Error()))
+			return
+		}
+
+		// Unhandled error occurred
+		rw.WriteHeader(500)
+		rw.Write([]byte(err.Error()))
 		return
 	}
 

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -1,0 +1,14 @@
+package cli
+
+import "net/http"
+
+type Router struct{}
+
+func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		rw.WriteHeader(400)
+		return
+	}
+	id := r.PathValue("UploadID")
+	rw.Write([]byte(id))
+}

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -31,7 +31,7 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = postprocessing.Deliver(r.Context(), id, nil, body.Target)
+	err = postprocessing.Deliver(r.Context(), id, body.Target)
 	if err != nil {
 		if errors.Is(err, postprocessing.ErrBadTarget) {
 			rw.WriteHeader(400)

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -91,6 +91,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, fileReadyPublishe
 
 	http.Handle("/info/{UploadID}", uploadInfoHandler)
 	http.Handle("/version", &VersionHandler{})
+	http.Handle("/route/{UploadID}", &Router{})
 
 	return http.DefaultServeMux, nil
 }

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/handlerdex"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/handlertusd"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
@@ -17,7 +16,7 @@ import (
 	"strings"
 )
 
-func Serve(ctx context.Context, appConfig appconfig.AppConfig, fileReadyPublisher event.Publisher[*event.FileReady]) (http.Handler, error) {
+func Serve(ctx context.Context, appConfig appconfig.AppConfig) (http.Handler, error) {
 	if sloger.DefaultLogger != nil {
 		logger = sloger.DefaultLogger
 	}
@@ -55,7 +54,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, fileReadyPublishe
 	}
 
 	// get and initialize tusd hook handlers
-	hookHandler, err := GetHookHandler(ctx, appConfig, fileReadyPublisher)
+	hookHandler, err := GetHookHandler(ctx, appConfig)
 	if err != nil {
 		logger.Error("error configuring tusd handler: ", "error", err)
 		return nil, err

--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -94,12 +94,12 @@ func main() {
 	event.InitFileReadyChannel()
 	defer event.CloseFileReadyChannel()
 
-	fileReadyPublisher, err := event.NewEventPublisher[*event.FileReady](ctx, appConfig)
+	err = event.InitFileReadyPublisher(ctx, appConfig)
+	defer event.FileReadyPublisher.Close()
 	if err != nil {
 		logger.Error("error creating file ready publisher", "error", err)
 		os.Exit(appMainExitCode)
 	}
-	defer fileReadyPublisher.Close()
 
 	mainWaitGroup.Add(1)
 	subscriber, err := cli.NewEventSubscriber[*event.FileReady](ctx, appConfig)
@@ -114,7 +114,7 @@ func main() {
 	}()
 
 	// start serving the app
-	_, err = cli.Serve(ctx, appConfig, fileReadyPublisher)
+	_, err = cli.Serve(ctx, appConfig)
 	if err != nil {
 		logger.Error("error starting app, error initialize dex handler", "error", err)
 		os.Exit(appMainExitCode)

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -117,8 +117,9 @@ type AzureQueueConfig struct {
 }
 
 type LocalStorageConfig struct {
-	FromPath fs.FS
-	ToPath   string
+	FromPathStr string
+	FromPath    fs.FS
+	ToPath      string
 }
 
 func (azc *AzureStorageConfig) Check() error {
@@ -160,23 +161,27 @@ func GetAzureContainerConfig(target string) (*AzureContainerConfig, error) {
 }
 
 func LocalStoreConfig(target string, appConfig *AppConfig) (*LocalStorageConfig, error) {
-	fromPath := os.DirFS(appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix)
+	fromPathStr := appConfig.LocalFolderUploadsTus + "/" + appConfig.TusUploadPrefix
+	fromPath := os.DirFS(fromPathStr)
 
 	switch target {
 	case "dex":
 		return &LocalStorageConfig{
-			FromPath: fromPath,
-			ToPath:   appConfig.LocalDEXFolder,
+			FromPathStr: fromPathStr,
+			FromPath:    fromPath,
+			ToPath:      appConfig.LocalDEXFolder,
 		}, nil
 	case "edav":
 		return &LocalStorageConfig{
-			FromPath: fromPath,
-			ToPath:   appConfig.LocalEDAVFolder,
+			FromPathStr: fromPathStr,
+			FromPath:    fromPath,
+			ToPath:      appConfig.LocalEDAVFolder,
 		}, nil
 	case "routing":
 		return &LocalStorageConfig{
-			FromPath: fromPath,
-			ToPath:   appConfig.LocalRoutingFolder,
+			FromPathStr: fromPathStr,
+			FromPath:    fromPath,
+			ToPath:      appConfig.LocalRoutingFolder,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported local target %s", target)

--- a/upload-server/internal/event/publish.go
+++ b/upload-server/internal/event/publish.go
@@ -18,12 +18,19 @@ import (
 )
 
 var logger *slog.Logger
+var FileReadyPublisher Publisher[*FileReady]
 
 func init() {
 	type Empty struct{}
 	pkgParts := strings.Split(reflect.TypeOf(Empty{}).PkgPath(), "/")
 	// add package name to app logger
 	logger = sloger.With("pkg", pkgParts[len(pkgParts)-1])
+}
+
+func InitFileReadyPublisher(ctx context.Context, appConfig appconfig.AppConfig) error {
+	p, err := NewEventPublisher[*FileReady](ctx, appConfig)
+	FileReadyPublisher = p
+	return err
 }
 
 type Publisher[T Identifiable] interface {

--- a/upload-server/internal/event/subscribe.go
+++ b/upload-server/internal/event/subscribe.go
@@ -46,7 +46,8 @@ func (ms *MemorySubscriber[T]) HandleSuccess(_ context.Context, e T) error {
 
 func (ms *MemorySubscriber[T]) HandleError(_ context.Context, e T, err error) error {
 	logger.Error("failed to handle event", "event", e, "error", err.Error())
-	ms.Chan <- e
+	// TODO simple retry
+	//ms.Chan <- e
 	return nil
 }
 

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -183,7 +183,7 @@ func (v *SenderManifestVerification) Verify(event handler.HookEvent, resp hooks.
 		return resp, errors.New("no Upload ID defined")
 	}
 
-	rb := reports.NewBuilder[reports.MetaDataVerifyContent](
+	rb := reports.NewBuilderWithManifest[reports.MetaDataVerifyContent](
 		"1.0.0",
 		reports.StageMetadataVerify,
 		tuid,
@@ -267,7 +267,7 @@ func (v *SenderManifestVerification) Hydrate(event handler.HookEvent, resp hooks
 		return resp, nil
 	}
 
-	rb := reports.NewBuilder[reports.BulkMetadataTransformReportContent](
+	rb := reports.NewBuilderWithManifest[reports.BulkMetadataTransformReportContent](
 		"1.0.0",
 		reports.StageMetadataTransform,
 		event.Upload.ID,
@@ -373,7 +373,7 @@ func WithUploadID(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookR
 	logger.Info("Generated UUID", "UUID", tuid)
 
 	manifest := event.Upload.MetaData
-	report := reports.NewBuilder[reports.BulkMetadataTransformReportContent](
+	report := reports.NewBuilderWithManifest[reports.BulkMetadataTransformReportContent](
 		"1.0.0",
 		reports.StageMetadataTransform,
 		tuid,
@@ -418,7 +418,7 @@ func WithTimestamp(event handler.HookEvent, resp hooks.HookResponse) (hooks.Hook
 	manifest[fieldname] = timestamp
 	resp.ChangeFileInfo.MetaData = manifest
 
-	report := reports.NewBuilder[reports.BulkMetadataTransformReportContent](
+	report := reports.NewBuilderWithManifest[reports.BulkMetadataTransformReportContent](
 		"1.0.0",
 		reports.StageMetadataTransform,
 		tguid,

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -359,7 +359,6 @@ func (aa *AzureMetadataAppender) Append(event handler.HookEvent, resp hooks.Hook
 	if err != nil {
 		return resp, err
 	}
-
 	return resp, nil
 }
 

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -2,7 +2,6 @@ package postprocessing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	metadataPkg "github.com/cdcgov/data-exchange-upload/upload-server/pkg/metadata"
@@ -22,6 +21,8 @@ import (
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/reports"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/sloger"
 )
+
+var ErrBadTarget = fmt.Errorf("bad delivery target")
 
 var targets = map[string]Deliverer{}
 
@@ -90,7 +91,7 @@ func NewAzureDeliverer(ctx context.Context, target string, appConfig *appconfig.
 func Deliver(ctx context.Context, tuid string, manifest map[string]string, target string) error {
 	d, ok := targets[target]
 	if !ok {
-		return errors.New("not recoverable, bad target " + target)
+		return ErrBadTarget
 	}
 
 	rb := reports.NewBuilder[reports.FileCopyContent](

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -282,9 +282,6 @@ func (ad *AzureDeliverer) GetMetadata(ctx context.Context, tuid string) (map[str
 	srcBlobClient := ad.FromContainerClient.NewBlobClient(ad.TusPrefix + "/" + tuid)
 	resp, err := srcBlobClient.GetProperties(ctx, nil)
 	if err != nil {
-		if err.Error() == string(bloberror.BlobNotFound) {
-			return nil, ErrSrcFileNotExist
-		}
 		return nil, err
 	}
 	return storeaz.DepointerizeMetadata(resp.Metadata), nil
@@ -300,7 +297,6 @@ func (ad *AzureDeliverer) GetDestUrl(ctx context.Context, tuid string, manifest 
 	if err != nil {
 		return "", err
 	}
-	// TODO Handle invalid blob client better.  Currently panics if blob client url doesn't exist or is not accessible.
 	destBlobClient := ad.ToContainerClient.NewBlobClient(blobName)
 	return destBlobClient.URL(), nil
 }

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -41,6 +41,11 @@ func RegisterTarget(name string, d Deliverer) {
 	targets[name] = d
 }
 
+func GetTarget(name string) (Deliverer, bool) {
+	d, ok := targets[name]
+	return d, ok
+}
+
 type Deliverer interface {
 	health.Checkable
 	Deliver(ctx context.Context, tuid string, metadata map[string]string) error
@@ -208,6 +213,13 @@ func (fd *FileDeliverer) GetMetadata(_ context.Context, tuid string) (map[string
 }
 
 func (fd *FileDeliverer) GetSrcUrl(_ context.Context, tuid string) (string, error) {
+	_, err := fs.Stat(fd.FromPath, tuid)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", ErrSrcFileNotExist
+		}
+		return "", err
+	}
 	return fd.FromPathStr + tuid, nil
 }
 

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -106,7 +106,6 @@ func Deliver(ctx context.Context, tuid string, target string) error {
 		reports.StageFileCopy,
 		tuid,
 		reports.DispositionTypeAdd).SetStartTime(time.Now().UTC())
-
 	manifest, err := d.GetMetadata(ctx, tuid)
 	if err != nil {
 		return err
@@ -140,7 +139,6 @@ func Deliver(ctx context.Context, tuid string, target string) error {
 		logger.Info("File Copy Report", "report", report)
 		reports.Publish(ctx, report)
 	}()
-
 	err = d.Deliver(ctx, tuid, manifest)
 	rb.SetEndTime(time.Now().UTC())
 	if err != nil {
@@ -317,6 +315,9 @@ func getDeliveredFilename(ctx context.Context, target string, tuid string, manif
 	filenameWithoutExtension := strings.TrimSuffix(filename, extension)
 
 	suffix, err := metadata.GetFilenameSuffix(ctx, manifest, tuid)
+	if err != nil {
+		return "", err
+	}
 	blobName := filenameWithoutExtension + suffix + extension
 
 	// Next, need to set the filename prefix based on config and target.

--- a/upload-server/internal/postprocessing/merge.go
+++ b/upload-server/internal/postprocessing/merge.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tus/tusd/v2/pkg/hooks"
 )
 
-func RouteAndDeliverHook(p evt.Publisher[*evt.FileReady]) func(handler.HookEvent, hooks.HookResponse) (hooks.HookResponse, error) {
+func RouteAndDeliverHook() func(handler.HookEvent, hooks.HookResponse) (hooks.HookResponse, error) {
 	return func(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
 		id := event.Upload.ID
 		var targets []string
@@ -29,7 +29,7 @@ func RouteAndDeliverHook(p evt.Publisher[*evt.FileReady]) func(handler.HookEvent
 
 		for _, target := range targets {
 			e := evt.NewFileReadyEvent(id, meta, target)
-			err := p.Publish(event.Context, e)
+			err := evt.FileReadyPublisher.Publish(event.Context, e)
 			if err != nil {
 				return resp, err
 			}

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -24,5 +24,5 @@ type PostProcessor struct {
 }
 
 func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
-	return Deliver(ctx, e.UploadId, e.Metadata, e.DestinationTarget)
+	return Deliver(ctx, e.UploadId, e.DestinationTarget)
 }

--- a/upload-server/internal/storeaz/blobutil.go
+++ b/upload-server/internal/storeaz/blobutil.go
@@ -56,7 +56,7 @@ func DepointerizeMetadata(metadata map[string]*string) map[string]string {
 	p := make(map[string]string)
 	for k, v := range metadata {
 		value := v
-		p[k] = *value
+		p[strings.ToLower(k)] = *value // For some reason, Azure blob sdk uses uppercase key names when pulling metadata from a blob
 	}
 
 	return p

--- a/upload-server/internal/storeaz/blobutil.go
+++ b/upload-server/internal/storeaz/blobutil.go
@@ -51,3 +51,13 @@ func PointerizeMetadata(metadata map[string]string) map[string]*string {
 
 	return p
 }
+
+func DepointerizeMetadata(metadata map[string]*string) map[string]string {
+	p := make(map[string]string)
+	for k, v := range metadata {
+		value := v
+		p[k] = *value
+	}
+
+	return p
+}

--- a/upload-server/internal/upload/report.go
+++ b/upload-server/internal/upload/report.go
@@ -29,7 +29,7 @@ func ReportUploadStatus(event handler.HookEvent, resp hooks.HookResponse) (hooks
 	uploadSize := event.Upload.Size
 	uploadMetadata := event.Upload.MetaData
 
-	report := reports.NewBuilder[reports.UploadStatusContent](
+	report := reports.NewBuilderWithManifest[reports.UploadStatusContent](
 		"1.0.0",
 		reports.StageUploadStatus,
 		uploadId,
@@ -58,7 +58,7 @@ func ReportUploadStarted(event handler.HookEvent, resp hooks.HookResponse) (hook
 	uploadSize := event.Upload.Size
 	logger.Info("Attempting to report upload started")
 
-	report := reports.NewBuilder[reports.UploadLifecycleContent](
+	report := reports.NewBuilderWithManifest[reports.UploadLifecycleContent](
 		"1.0.0",
 		reports.StageUploadStarted,
 		uploadId,
@@ -71,7 +71,7 @@ func ReportUploadStarted(event handler.HookEvent, resp hooks.HookResponse) (hook
 	}).Build()
 	reports.Publish(event.Context, report)
 
-	report = reports.NewBuilder[reports.UploadStatusContent](
+	report = reports.NewBuilderWithManifest[reports.UploadStatusContent](
 		"1.0.0",
 		reports.StageUploadStatus,
 		uploadId,
@@ -100,7 +100,7 @@ func ReportUploadComplete(event handler.HookEvent, resp hooks.HookResponse) (hoo
 	uploadSize := event.Upload.Size
 	logger.Info("Attempting to report upload completed", "uploadId", uploadId)
 
-	report := reports.NewBuilder[reports.UploadLifecycleContent](
+	report := reports.NewBuilderWithManifest[reports.UploadLifecycleContent](
 		"1.0.0",
 		reports.StageUploadCompleted,
 		uploadId,
@@ -113,7 +113,7 @@ func ReportUploadComplete(event handler.HookEvent, resp hooks.HookResponse) (hoo
 	}).Build()
 	reports.Publish(event.Context, report)
 
-	report = reports.NewBuilder[reports.UploadStatusContent](
+	report = reports.NewBuilderWithManifest[reports.UploadStatusContent](
 		"1.0.0",
 		reports.StageUploadStatus,
 		uploadId,

--- a/upload-server/pkg/reports/builder.go
+++ b/upload-server/pkg/reports/builder.go
@@ -122,7 +122,19 @@ type Builder[T any] interface {
 	Build() *Report
 }
 
-func NewBuilder[T any](version string, stage string, uploadId string, manifest map[string]string, dispType string) Builder[T] {
+func NewBuilder[T any](version string, stage string, uploadId string, dispType string) Builder[T] {
+	return &ReportBuilder[T]{
+		Version:         version,
+		Stage:           stage,
+		UploadId:        uploadId,
+		DispositionType: dispType,
+		Status:          StatusSuccess,
+		StartTime:       time.Now().UTC(),
+		EndTime:         time.Now().UTC(),
+	}
+}
+
+func NewBuilderWithManifest[T any](version string, stage string, uploadId string, manifest map[string]string, dispType string) Builder[T] {
 	return &ReportBuilder[T]{
 		Version:         version,
 		Stage:           stage,

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -136,7 +136,7 @@ func TestTus(t *testing.T) {
 					if resp.StatusCode != http.StatusOK {
 						t.Error("expected 200 when retrying route but got", resp.StatusCode)
 					}
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(100 * time.Millisecond) // Wait for new file ready event to be processed.
 					if _, err := os.Stat("./test/edav/" + tuid); errors.Is(err, os.ErrNotExist) {
 						t.Error("file was not copied to edav checkpoint when retry attempted for file", tuid)
 					}
@@ -365,37 +365,6 @@ func TestRouteFileNotFound(t *testing.T) {
 		t.Error("Expected 404 but got", resp.StatusCode)
 	}
 }
-
-//func TestRouteFileSuccess(t *testing.T) {
-//	// First, write a file to the upload dir
-//	err := os.Mkdir("./test/uploads", 0755)
-//	if err != nil {
-//		t.Fatal(err.Error())
-//	}
-//	defer os.RemoveAll("./test/uploads")
-//	err = os.WriteFile("./test/uploads/test", []byte("hello"), 0644)
-//	if err != nil {
-//		t.Fatal(err.Error())
-//	}
-//	err = os.WriteFile("./test/uploads/test.meta", []byte("test meta"), 0644)
-//	if err != nil {
-//		t.Fatal(err.Error())
-//	}
-//	// Next, send a post to the route endpoint
-//	client := ts.Client()
-//	b := []byte(`{
-//		"target": "edav"
-//	}`)
-//	resp, err := client.Post(ts.URL+"/route/test", "application/json", bytes.NewBuffer(b))
-//	if err != nil {
-//		t.Fatal(err.Error())
-//	}
-//	if resp.StatusCode != 200 {
-//		t.Error("Expected 200 but got", resp.StatusCode)
-//	}
-//	// Then, assert that the file was copied to the target
-//	// TODO might need to wait a few milliseconds before checking
-//}
 
 func TestMain(m *testing.M) {
 	appConfig := appconfig.AppConfig{

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -121,7 +121,7 @@ func TestTus(t *testing.T) {
 					}
 
 					// Remove and re-route the file
-					// TODO probably best if this was in its own test but this is at least good for happy path test for now
+					// TODO probably best if this was in its own test function but this is at least good for happy path test for now
 					err = os.Remove("./test/edav/" + tuid)
 					if err != nil {
 						t.Error("failed to remove edav file for "+tuid, err.Error())

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -297,6 +298,49 @@ func TestRouteBadRequest(t *testing.T) {
 	}
 	if resp.StatusCode != 400 {
 		t.Error("Expected 400 but got", resp.StatusCode)
+	}
+}
+
+func TestRouteInvalidBody(t *testing.T) {
+	client := ts.Client()
+	b := []byte("blah")
+	resp, err := client.Post(ts.URL+"/route/1234", "application/json", bytes.NewBuffer(b))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("Expected 400 but got", resp.StatusCode)
+	}
+}
+
+func TestRouteInvalidTarget(t *testing.T) {
+	client := ts.Client()
+	b := []byte(`{
+		"target": "blah"
+	}`)
+	resp, err := client.Post(ts.URL+"/route/1234", "application/json", bytes.NewBuffer(b))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("Expected 400 but got", resp.StatusCode)
+	}
+}
+
+func TestRouteFileNotFound(t *testing.T) {
+	client := ts.Client()
+	b := []byte(`{
+		"target": "edav"
+	}`)
+	resp, err := client.Post(ts.URL+"/route/1234", "application/json", bytes.NewBuffer(b))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 404 {
+		t.Error("Expected 404 but got", resp.StatusCode)
 	}
 }
 

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -288,6 +288,18 @@ func TestFileInfoNotFound(t *testing.T) {
 	}
 }
 
+func TestRouteBadRequest(t *testing.T) {
+	client := ts.Client()
+	resp, err := client.Get(ts.URL + "/route/1234")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 400 {
+		t.Error("Expected 400 but got", resp.StatusCode)
+	}
+}
+
 func TestMain(m *testing.M) {
 	appConfig := appconfig.AppConfig{
 		UploadConfigPath:      "../../upload-configs/",


### PR DESCRIPTION
Adds a new endpoint at the path `/route/<uuid>` that accepts a post request with the following body:
```
{
  "target": "routing" | "edav"
}
```

When this request is received, the service attempts to redeliver the file to the specified target.  It returns a 200 if it was able to find the file and re-issue the delivery operation.  It returns a 400 if the request operation is not POST, the body is malformed, or if the target is not supported.  It returns a 404 if the file is not found.
