### PR TITLE
set folder prefix using datastream and route

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -116,16 +116,21 @@ func GetConfigIdentifierByVersion(manifest handler.MetaData) (string, error) {
 }
 
 func GetFilenamePrefix(ctx context.Context, manifest handler.MetaData) (string, error) {
-	p := ""
 	config, err := GetConfigFromManifest(ctx, manifest)
 	if err != nil {
-		return p, err
+		return "", err
 	}
+
+	ds := metadata.GetDataStreamID(manifest)
+	r := metadata.GetDataStreamRoute(manifest)
+
+	p := ds + "-" + r
 
 	if config.Copy.FolderStructure == FolderStructureDate {
 		// Get UTC year, month, and day
 		t := time.Now().UTC()
-		p = fmt.Sprintf("%d/%02d/%02d/", t.Year(), t.Month(), t.Day())
+		datePrefix := fmt.Sprintf("%d/%02d/%02d/", t.Year(), t.Month(), t.Day())
+		p = p + "/" + datePrefix
 	}
 
 	return p, nil

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -337,8 +337,7 @@ func getDeliveredFilename(ctx context.Context, target string, tuid string, manif
 	prefix := ""
 
 	switch target {
-	case "edav":
-	case "routing":
+	case "routing", "edav":
 		prefix, err = metadata.GetFilenamePrefix(ctx, manifest)
 		if err != nil {
 			return "", err

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -225,9 +225,13 @@ func TestGetFileDeliveryPrefixDate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dateTokens := strings.Split(p, "/")
-	if len(dateTokens) != 4 {
-		t.Error("date prefix not properly formatted", p)
+	prefixTokens := strings.Split(p, "/")
+	if len(prefixTokens) != 5 {
+		t.Error("prefix not properly formatted", p)
+	}
+	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
+	if prefixTokens[0] != expectedFolderPrefix {
+		t.Error("prefix folder not properly formatted")
 	}
 }
 
@@ -248,8 +252,10 @@ func TestGetFileDeliveryPrefixRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p != "" {
-		t.Error("expected file delivery prefix to be empty but was", p)
+	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
+
+	if p != expectedFolderPrefix {
+		t.Error("expected file delivery prefix to be folder prefix but was", p)
 	}
 }
 


### PR DESCRIPTION
Fixes folder prefix logic to apply logic to edav and routing destinations.  Also tweaks logic to add a folder prefix using the data steam and route.