### PR TITLE
Dockerfile update

### DIFF
--- a/upload-server/Dockerfile
+++ b/upload-server/Dockerfile
@@ -4,9 +4,9 @@ ARG REPO="cdcgov/data-exchange-upload"
 ARG LATEST_RELEASE_VERSION="unspecified"
 ARG GIT_SHORT_SHA="unspecified"
 
-WORKDIR /app 
+WORKDIR /app
 
-COPY go.mod go.sum ./ 
+COPY go.mod go.sum ./
 
 RUN go mod download
 
@@ -16,11 +16,9 @@ RUN go build -ldflags "-X github.com/cdcgov/data-exchange-upload/upload-server/i
     -X github.com/cdcgov/data-exchange-upload/upload-server/internal/version.LatestReleaseVersion=${LATEST_RELEASE_VERSION} \
     -X github.com/cdcgov/data-exchange-upload/upload-server/internal/version.GitShortSha=${GIT_SHORT_SHA}" -o ./dextusd ./cmd/main.go
 
-#
+FROM docker.io/library/alpine:3.20.2
 
-FROM alpine:latest 
-
-WORKDIR /app 
+WORKDIR /app
 
 COPY --from=builder /app/dextusd .
 


### PR DESCRIPTION
In response to this Fortify Scan Result: https://cdc-dexops.atlassian.net/browse/UPLOAD-1550

Attempt to fix the `Dockerfile Misconfiguration: Dependency Confusion` by giving a specific version to the `alpine` image