### PR TITLE
UPLOAD-1647/bugfix-event-handle-error-improvement

### DIFF
--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -87,6 +87,7 @@ func main() {
 	logger.Info("starting app")
 
 	// Pub Sub
+	event.MaxRetries = appConfig.EventMaxRetryCount
 	// initialize event reporter
 	err := cli.InitReporters(ctx, appConfig)
 	defer reports.DefaultReporter.Close()

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -41,7 +41,8 @@ type AppConfig struct {
 	// Server
 	ServerPort string `env:"SERVER_PORT, default=8080"`
 	//QUESTION: this is arbitrary so is it useful?
-	Environment string `env:"ENVIRONMENT, default=DEV"`
+	Environment        string `env:"ENVIRONMENT, default=DEV"`
+	EventMaxRetryCount int    `env:"EVENT_MAX_RETRY_COUNT, default=3"`
 
 	UploadConfigPath string `env:"UPLOAD_CONFIG_PATH, default=../upload-configs"`
 

--- a/upload-server/internal/event/event.go
+++ b/upload-server/internal/event/event.go
@@ -7,8 +7,8 @@ import (
 )
 
 const FileReadyEventType = "FileReady"
-const MaxRetries = 3
 
+var MaxRetries int
 var FileReadyChan chan *FileReady
 
 type Retryable interface {

--- a/upload-server/internal/event/subscribe.go
+++ b/upload-server/internal/event/subscribe.go
@@ -46,8 +46,13 @@ func (ms *MemorySubscriber[T]) HandleSuccess(_ context.Context, e T) error {
 
 func (ms *MemorySubscriber[T]) HandleError(_ context.Context, e T, err error) error {
 	logger.Error("failed to handle event", "event", e, "error", err.Error())
-	// TODO simple retry
-	//ms.Chan <- e
+	if e.RetryCount() < MaxRetries {
+		e.IncrementRetryCount()
+		// Retrying in a separate go routine so this doesn't block on channel write.
+		go func() {
+			ms.Chan <- e
+		}()
+	}
 	return nil
 }
 

--- a/upload-server/pkg/reports/reports.go
+++ b/upload-server/pkg/reports/reports.go
@@ -20,7 +20,12 @@ func init() {
 }
 
 func Publish(ctx context.Context, r *Report) {
-	if err := DefaultReporter.Publish(ctx, r); err != nil {
+	err := DefaultReporter.Publish(ctx, r)
+	if err != nil {
 		logger.Error("Failed to report", "report", r, "reporter", DefaultReporter, "err", err)
+		if r.RetryCount() < event.MaxRetries {
+			r.IncrementRetryCount()
+			Publish(ctx, r)
+		}
 	}
 }


### PR DESCRIPTION
This patch addresses an issue with the in-memory subscriber in which when an error occurred during the handling of an event, the go routine would hang because it would attempt to retry by putting the event back on the channel.  This is an unbuffered channel, so the go routine would block until something read the channel, but this would result in a deadlock because the parent go routine would wait for this go routine to complete before reading the channel again.  

A simple retry mechanism was implemented to mitigate this.  Events now contain a new field that holds a retry count.  When an error occurred during the handling of this event, the process will check if the count is less than some max number.  If that's true, it will put the event back on the channel but in a new go routine.  If it's false, it will just log the error and return.