### PR TITLE
add trailing slash for files with no date prefix

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -124,13 +124,13 @@ func GetFilenamePrefix(ctx context.Context, manifest handler.MetaData) (string, 
 	ds := metadata.GetDataStreamID(manifest)
 	r := metadata.GetDataStreamRoute(manifest)
 
-	p := ds + "-" + r + "/"
+	p := ds + "-" + r
 
 	if config.Copy.FolderStructure == FolderStructureDate {
 		// Get UTC year, month, and day
 		t := time.Now().UTC()
-		datePrefix := fmt.Sprintf("%d/%02d/%02d/", t.Year(), t.Month(), t.Day())
-		p = p + datePrefix
+		datePrefix := fmt.Sprintf("%d/%02d/%02d", t.Year(), t.Month(), t.Day())
+		p = filepath.Join(p, datePrefix)
 	}
 
 	return p, nil

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -124,13 +124,13 @@ func GetFilenamePrefix(ctx context.Context, manifest handler.MetaData) (string, 
 	ds := metadata.GetDataStreamID(manifest)
 	r := metadata.GetDataStreamRoute(manifest)
 
-	p := ds + "-" + r
+	p := ds + "-" + r + "/"
 
 	if config.Copy.FolderStructure == FolderStructureDate {
 		// Get UTC year, month, and day
 		t := time.Now().UTC()
 		datePrefix := fmt.Sprintf("%d/%02d/%02d/", t.Year(), t.Month(), t.Day())
-		p = p + "/" + datePrefix
+		p = p + datePrefix
 	}
 
 	return p, nil

--- a/upload-server/internal/postprocessing/deliver.go
+++ b/upload-server/internal/postprocessing/deliver.go
@@ -344,5 +344,5 @@ func getDeliveredFilename(ctx context.Context, target string, tuid string, manif
 		}
 	}
 
-	return prefix + blobName, nil
+	return filepath.Join(prefix, blobName), nil
 }

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -225,8 +226,8 @@ func TestGetFileDeliveryPrefixDate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	prefixTokens := strings.Split(p, "/")
-	if len(prefixTokens) != 5 {
+	prefixTokens := strings.Split(p, string(filepath.Separator))
+	if len(prefixTokens) != 4 {
 		t.Error("prefix not properly formatted", p)
 	}
 	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
@@ -252,7 +253,7 @@ func TestGetFileDeliveryPrefixRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"] + "/"
+	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
 
 	if p != expectedFolderPrefix {
 		t.Error("expected file delivery prefix to be folder prefix but was", p)

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -252,7 +252,7 @@ func TestGetFileDeliveryPrefixRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
+	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"] + "/"
 
 	if p != expectedFolderPrefix {
 		t.Error("expected file delivery prefix to be folder prefix but was", p)


### PR DESCRIPTION
This patch tweaks the logic for generating the upload file prefix by adding a trailing slash for all files and not just ones with the date prefix.