### PR TITLE
Upload 1658/s3 config loader

### DIFF
--- a/upload-server/cmd/cli/datastore.go
+++ b/upload-server/cmd/cli/datastore.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/stores3"
 	"github.com/tus/tusd/v2/pkg/s3store"
 	"os"
@@ -58,18 +56,10 @@ func GetDataStore(ctx context.Context, appConfig appconfig.AppConfig) (handlertu
 	} // .if
 
 	if appConfig.S3Connection != nil {
-		cfg, err := config.LoadDefaultConfig(ctx)
-
+		client, err := stores3.New(ctx, appConfig.S3Connection)
 		if err != nil {
 			return nil, nil, err
 		}
-		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-			// For non-AWS S3 backends
-			if appConfig.S3Connection.Endpoint != "" {
-				o.UsePathStyle = true
-				o.BaseEndpoint = &appConfig.S3Connection.Endpoint
-			}
-		})
 		hc := &stores3.S3HealthCheck{
 			Client: client,
 		}

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -75,6 +75,9 @@ type AppConfig struct {
 	AzureManifestConfigContainer string `env:"DEX_MANIFEST_CONFIG_CONTAINER_NAME"`
 	TusUploadPrefix              string `env:"TUS_UPLOAD_PREFIX, default=tus-prefix"`
 
+	// S3
+	S3ManifestConfigBucket string `env:"DEX_MANIFEST_CONFIG_BUCKET_NAME"`
+
 	// Upload processing
 	DexCheckpointContainer     string `env:"DEX_CHECKPOINT_CONTAINER_NAME, default=dex-checkpoint"`
 	EdavCheckpointContainer    string `env:"EDAV_CHECKPOINT_CONTAINER_NAME, default=edav-checkpoint"`

--- a/upload-server/internal/loaders/s3.go
+++ b/upload-server/internal/loaders/s3.go
@@ -1,0 +1,25 @@
+package loaders
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"io"
+)
+
+type S3ConfigLoader struct {
+	Client     *s3.Client
+	BucketName string
+}
+
+func (l *S3ConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte, error) {
+	output, err := l.Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: &l.BucketName,
+		Key:    &path,
+	})
+	if err != nil {
+
+		return nil, err
+	}
+
+	return io.ReadAll(output.Body)
+}

--- a/upload-server/internal/stores3/client.go
+++ b/upload-server/internal/stores3/client.go
@@ -1,0 +1,25 @@
+package stores3
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
+)
+
+func New(ctx context.Context, s3Config *appconfig.S3StorageConfig) (*s3.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		// For non-AWS S3 backends
+		if s3Config.Endpoint != "" {
+			o.UsePathStyle = true
+			o.BaseEndpoint = &s3Config.Endpoint
+		}
+	})
+
+	return client, nil
+}


### PR DESCRIPTION
Adds an implementation for loading an upload config from an S3 bucket.

TODO:
- Tidying.  There's some structural improvements we can make here for the secondary objects that depend on the environment the service is deployed in.  That includes the config loader, appender, locker, and router.  It would be great if we could initialize these objects in a more composable way, such as
```
hookHandler
  .withConfigLoader()
  .withMetadataAppender()
  .withRouter()
```
This is just an example.  Can also use option functions as that's a common pattern for composition in Go as well.