### PR TITLE
UPLOAD-1666/bugfix append tuid to metadata

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -380,8 +380,8 @@ func WithPreCreateManifestTransforms(event handler.HookEvent, resp hooks.HookRes
 	logger.Info("adding global timestamp", "timestamp", timestamp)
 
 	manifest := event.Upload.MetaData
-	fieldname := "dex_ingest_datetime"
-	manifest[fieldname] = timestamp
+	manifest["dex_ingest_datetime"] = timestamp
+	manifest["upload_id"] = tuid
 	resp.ChangeFileInfo.MetaData = manifest
 
 	report := reports.NewBuilderWithManifest[reports.BulkMetadataTransformReportContent](
@@ -399,8 +399,12 @@ func WithPreCreateManifestTransforms(event handler.HookEvent, resp hooks.HookRes
 				Field: "ID",
 				Value: tuid}, {
 				Action: "append",
-				Field:  fieldname,
+				Field:  "dex_ingest_datetime",
 				Value:  timestamp,
+			}, {
+				Action: "append",
+				Field:  "upload_id",
+				Value:  tuid,
 			}},
 	}).Build()
 

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -184,6 +184,13 @@ func TestTus(t *testing.T) {
 						}
 					}
 				}
+
+				appendedUid, ok := processedMeta["upload_id"]
+				if !ok {
+					t.Error("upload ID not appended to file metadata")
+				} else if appendedUid != tuid {
+					t.Error("appended upload ID did not match upload ID", appendedUid, tuid)
+				}
 			}
 
 			t.Log("test case", name, "passed", tuid)


### PR DESCRIPTION
Appends the upload ID to the metadata map.  This was a behavior in the new deprecated upload processor that needs to be replicated to the upload server.  This implementation appends the uid to the metadata in the pre-create step.  That way, when the append operation is executed in the pre-finish step, the uid is already there.

Testing steps:
1. Run the server locally
2. Upload a file
3. Locate the .meta file for the file you uploaded.  It should be located in ./uploads/tus-prefix. The filename will have the same upload ID that was generated.  So if the upload ID is 1234, the .meta file will be 1234.meta
4. In the JSON content within this file, observe that there is a field for `upload_id` with the value of the upload ID for the file you uploaded