### PR TITLE
1676: Progress Bar for UI

### DIFF
--- a/upload-server/internal/ui/assets/demo.js
+++ b/upload-server/internal/ui/assets/demo.js
@@ -126,7 +126,7 @@
   
           const percentageFile = ((fileBytesUploaded / fileBytesTotal) * 100).toFixed(2)
           const percentageTotal = ((fileListBytesUploaded / fileListBytesTotal) * 100).toFixed(2)
-          const percentageTotalRound = ((fileListBytesUploaded / fileListBytesTotal) * 100).toFixed(0)
+          const percentageTotalRound = Math.round(percentageTotal)
 
           if (percentageTotal >= 100) {
             progressContainer.classList.add('hidden')

--- a/upload-server/internal/ui/assets/demo.js
+++ b/upload-server/internal/ui/assets/demo.js
@@ -6,14 +6,14 @@
   let upload          = null
   let uploadIsRunning = false
 
-  const input           = document.querySelector('input[type=file]')
-  const progress        = document.querySelector('.progress')
-  const progressBar     = progress.querySelector('.bar')
-  const alertBox        = document.querySelector('#support-alert')
-  const uploadList      = document.querySelector('#upload-list')
-  const chunkInput      = document.querySelector('#chunksize')
-  const parallelInput   = document.querySelector('#paralleluploads')
-  const endpointInput   = document.querySelector('#endpoint')
+  const input               = document.querySelector('input[type=file]')
+  const progressContainer   = document.querySelector('.progress')
+  const progressBar         = progressContainer.querySelector('.bar')
+  const alertBox            = document.querySelector('#support-alert')
+  const uploadList          = document.querySelector('#upload-list')
+  const chunkInput          = document.querySelector('#chunksize')
+  const parallelInput       = document.querySelector('#paralleluploads')
+  const endpointInput       = document.querySelector('#endpoint')
 
 
   function reset (startTimeUpload, fileListBytesUploaded, fileListBytesTotal) {
@@ -126,8 +126,17 @@
   
           const percentageFile = ((fileBytesUploaded / fileBytesTotal) * 100).toFixed(2)
           const percentageTotal = ((fileListBytesUploaded / fileListBytesTotal) * 100).toFixed(2)
-  
-          progressBar.style.width = `${percentageTotal}%`
+          const percentageTotalRound = ((fileListBytesUploaded / fileListBytesTotal) * 100).toFixed(0)
+
+          if (percentageTotal >= 100) {
+            progressContainer.classList.add('hidden')
+            progressBar.style.width = 0
+          } else {
+            progressContainer.classList.remove('hidden')
+            progressBar.classList.remove('hidden')
+            progressBar.style.width = `${percentageTotal}%`
+            progressBar.textContent = `${percentageTotalRound}%`
+          }
   
           console.log('file:', file.name, fileBytesUploaded, fileBytesTotal, `${percentageFile}%`)
           console.log('fileList (total):', fileListBytesUploaded, fileListBytesTotal, `${percentageTotal}%`)

--- a/upload-server/internal/ui/assets/progress.css
+++ b/upload-server/internal/ui/assets/progress.css
@@ -1,0 +1,20 @@
+.progress-container {
+	height: 32px;
+  width: 50%;
+  max-width: 400px;
+}
+
+.progress {
+  border: 1px solid #aaa;
+	height: 100%;
+  width: 100%;
+}
+
+.bar {
+  background-color: rgb(6, 162, 6);
+  color: white;
+  line-height: 30px;
+  height: 100%;
+  margin: auto 0;
+  padding-left: 10px;
+}

--- a/upload-server/internal/ui/manifest.tmpl
+++ b/upload-server/internal/ui/manifest.tmpl
@@ -24,12 +24,12 @@
               </label>
               {{if not .AllowedValues}}
                 {{ if .Required }}
-                  <input id="{{.FieldName}}" id="{{.FieldName}}" type="text" required/>
+                  <input id="{{.FieldName}}" name="{{.FieldName}}" type="text" required/>
                 {{ else }}
-                  <input id="{{.FieldName}}" id="{{.FieldName}}" type="text" />
+                  <input id="{{.FieldName}}" name="{{.FieldName}}" type="text" />
                 {{ end }}
               {{ else }}
-              <select id="{{.FieldName}}">
+              <select name="{{.FieldName}}" id="{{.FieldName}}">
                 {{range .AllowedValues}}
                   <option value="{{.}}">{{.}}</option>
                 {{end}}
@@ -39,11 +39,11 @@
             {{end}}
             <div class="hidden">
               <label for="data_stream_id">Data Stream ID</label>
-              <input id="data_stream_id" id="data_stream_id" type="text" value="{{.DataStream}}" />
+              <input id="data_stream_id" name="data_stream_id" type="text" value="{{.DataStream}}" />
             </div>
             <div class="hidden">
               <label for="data_stream_route">Data Stream Route</label>
-              <input id="data_stream_route" id="data_stream_route" type="text" value="{{.DataStreamRoute}}" />
+              <input id="data_stream_route" name="data_stream_route" type="text" value="{{.DataStreamRoute}}" />
             </div>
             <button type="submit">Next</button>
           </form>

--- a/upload-server/internal/ui/upload.tmpl
+++ b/upload-server/internal/ui/upload.tmpl
@@ -4,6 +4,7 @@
         <meta charset="UTF-8">
         <link rel="stylesheet" href="/assets/index.css">
         <link rel="stylesheet" href="/assets/form.css">
+        <link rel="stylesheet" href="/assets/progress.css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>DEX Upload</title>
     </head>
@@ -67,9 +68,9 @@
                 </div>
 
                 <div class="row">
-                    <div class="span8">
-                    <div class="progress progress-striped progress-success">
-                        <div class="bar" style="width: 0%;"></div>
+                    <div class="span8 progress-container">
+                    <div class="progress progress-striped progress-success hidden">
+                        <div class="bar hidden" style="width: 0%;">Uploading...</div>
                     </div>
                     </div>
                     <!-- <div class="span4">

--- a/upload-server/internal/ui/upload.tmpl
+++ b/upload-server/internal/ui/upload.tmpl
@@ -70,7 +70,7 @@
                 <div class="row">
                     <div class="span8 progress-container">
                     <div class="progress progress-striped progress-success hidden">
-                        <div class="bar hidden" style="width: 0%;">Uploading...</div>
+                        <div class="bar hidden" style="width: 0%;"></div>
                     </div>
                     </div>
                     <!-- <div class="span4">


### PR DESCRIPTION
To make the UI more accessible, provide a visual representation for the upload process.

To test:

- Run locally and go thru the UI to upload an item
- In order to make the upload longer, change the chunk size to a two or three digit number

![Screenshot 2024-08-26 at 2 16 50 PM](https://github.com/user-attachments/assets/2884c7ba-19d5-432c-a347-62c9b9b2ba26)
