### PR TITLE
fix 404 when getting compat config file

### DIFF
--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -291,18 +291,10 @@ func (v *SenderManifestVerification) getHydrationConfig(ctx context.Context, man
 		return nil, err
 	}
 	if c.CompatConfigFilename != "" {
-		return v.Configs.GetConfig(ctx, c.CompatConfigFilename)
+		return v.Configs.GetConfig(ctx, "v2/" + c.CompatConfigFilename)
 	}
 
-	//TODO: don't trigger this this way, it's a weird sideaffect
-	manifest["version"] = "2.0"
-	manifest["data_stream_id"] = manifest["meta_destination_id"]
-	manifest["data_stream_route"] = manifest["meta_ext_event"]
-	path, err = GetConfigIdentifierByVersion(manifest)
-	if err != nil {
-		return nil, err
-	}
-	return v.Configs.GetConfig(ctx, strings.ToLower(path))
+	return c, nil
 }
 
 func (v *SenderManifestVerification) Hydrate(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {

--- a/upload-server/internal/metadata/v1/manifest.go
+++ b/upload-server/internal/metadata/v1/manifest.go
@@ -51,5 +51,8 @@ func Hydrate(m map[string]string, config *validation.ManifestConfig) (map[string
 			})
 		}
 	}
+	m["version"] = "2.0"
+	m["data_stream_id"] = m["meta_destination_id"]
+	m["data_stream_route"] = m["meta_ext_event"]
 	return m, transforms
 }

--- a/upload-server/testing/testing.go
+++ b/upload-server/testing/testing.go
@@ -120,6 +120,20 @@ var Cases = map[string]testCase{
 		},
 		nil,
 	},
+	"ndlp v1 good": {
+		tus.Metadata{
+			"meta_destination_id": "ndlp",
+			"meta_ext_event": "covidallmonthlyvaccination",
+			"meta_ext_filename": "test",
+			"meta_ext_objectkey": "test",
+			"meta_ext_source": "IZGW",
+			"meta_ext_sourceversion": "V2023-09-01",
+			"meta_ext_submissionperiod": "test",
+			"meta_username": "test",
+			"meta_ext_entity": "AKA",
+		},
+		nil,
+	},
 }
 
 func RunTusTestCase(url string, testFile string, c testCase) (string, error) {


### PR DESCRIPTION
This patch fixes an issue when uploading files with a v1 manifest that has a non-standard v2 config.  Manifests of this type use a special field in their configs called `CompatConfigFilename` to select the v2 config used to hydrate the file.  An example of a config of this type can be found here: https://github.com/CDCgov/data-exchange-upload/blob/main/upload-configs/v1/aims-celr-csv.json#L77

The server was failing to look in the `v2` subdirectory when fetching configs in this way, resulting in a 404 and the file ultimately not being delivered, and metadata not being appended to it.

This patch addresses this issue by prepending "v2" to the path to the config.  A unit test was also added to cover the case where a manifest of this type is used.

Tickets: https://cdc-dexops.atlassian.net/browse/UPLOAD-1688, https://cdc-dexops.atlassian.net/browse/UPLOAD-1689
Test steps: 
1. Point a tus client at the stg or tst environment
2. Upload a file with the following metadata
```
metadata: {
      filename: "chase-test-bug",
      filetype: "text/plain",
      meta_destination_id: "ndlp",
      meta_ext_event: "covidallmonthlyvaccination",
      meta_ext_filename: "chase-test-bug",
      meta_ext_objectkey: "bug fix obj key",
      meta_ext_source: "IZGW",
      meta_ext_sourceversion: "V2023-09-01",
      meta_ext_submissionperiod: "blah",
      meta_username: "blah",
      meta_ext_entity: "AKA"
    }
```
3. Observe that the file in tus storage has the metadata appended to it with hydrated v2 fields
4. Observe that the file is copied to the appropriate destination