### PR TITLE
created a GHA in the main repo that remote-triggers a test deployment

### DIFF
--- a/.github/workflows/build-and-deploy-branch-tst.yml
+++ b/.github/workflows/build-and-deploy-branch-tst.yml
@@ -1,0 +1,18 @@
+name: TST - Build and Deploy Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      REF:
+        description: Branch from CDCgov/data-exchange-upload that you want to deploy to the tst environment.
+        default: main
+        required: true
+        type: string
+
+jobs:
+  remote-trigger:
+    uses: ./.github/workflows/remote-cd-trigger-template.yml
+    with:
+      WORKFLOW: build-and-deploy-branch-tst.yml
+      REF: ${{ inputs.REF }}
+    secrets: inherit


### PR DESCRIPTION
Created a GHA for this repo that remote triggers "TST - Build and Deploy Branch" GHA in the devops repo. This will make deploying branches to the TST environment easier and prevent copy/paste errors that could happen when you have to manually enter the branch name.