### PR TITLE
update H5 flu vax config

### DIFF
--- a/upload-configs/v2/h5-influenza-vaccination-csv.json
+++ b/upload-configs/v2/h5-influenza-vaccination-csv.json
@@ -4,20 +4,15 @@
 		"fields": [
 			{
 				"field_name": "sender_id",
+				"required": true,
 				"allowed_values": [
 					"IZGW"
 				],
-				"required": true,
-				"description": "This field is the identifier for the sender of the data.",
-				"compat_field_name": "meta_ext_source"
+				"description": "This field is the identifier for the sender of the data."
 			},
 			{
 				"field_name": "data_producer_id",
 				"required": true,
-				"description": "This field is the identifier for the data producer."
-			},
-			{
-				"field_name": "jurisdiction",
 				"allowed_values": [
 					"AKA",
 					"ALA",
@@ -113,66 +108,163 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
-				],
+					"FD3",
+					"XXA"
+				],				
+				"description": "This field is the identifier for the data producer."
+			},
+			{
+				"field_name": "jurisdiction",
 				"required": true,
-				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
-				"compat_field_name": "meta_ext_entity"
+				"allowed_values": [
+					"AKA",
+					"ALA",
+					"ASA",
+					"AZA",
+					"ARA",
+					"CAA",
+					"CHA",
+					"COA",
+					"CTA",
+					"DEA",
+					"DCA",
+					"FMA",
+					"FLA",
+					"GAA",
+					"GUA",
+					"HIA",
+					"IDA",
+					"ILA",
+					"IAA",
+					"INA",
+					"KSA",
+					"KYA",
+					"LAA",
+					"MEA",
+					"MHA",
+					"MDA",
+					"MAA",
+					"MIA",
+					"MNA",
+					"MSA",
+					"MOA",
+					"MTA",
+					"NEA",
+					"NHA",
+					"NJA",
+					"NMA",
+					"BAA",
+					"NYA",
+					"NCA",
+					"NDA",
+					"NVA",
+					"MPA",
+					"OHA",
+					"OKA",
+					"ORA",
+					"PAA",
+					"PHA",
+					"PRA",
+					"RPA",
+					"RIA",
+					"SCA",
+					"SDA",
+					"TNA",
+					"TXA",
+					"UTA",
+					"VTA",
+					"VIA",
+					"VAA",
+					"WAA",
+					"WVA",
+					"WIA",
+					"WYA",
+					"DD2",
+					"HS2",
+					"DS2",
+					"BP2",
+					"IH2",
+					"VA2",
+					"CV1",
+					"WG1",
+					"WM1",
+					"RA1",
+					"KG1",
+					"AB1",
+					"PX1",
+					"AD1",
+					"CW1",
+					"HE1",
+					"HV1",
+					"MG1",
+					"SE1",
+					"MS1",
+					"HM1",
+					"GN1",
+					"TP1",
+					"CP1",
+					"MH1",
+					"GM1",
+					"PI1",
+					"TBA",
+					"THA",
+					"HH2",
+					"HR2",
+					"DV3",
+					"FD3",
+					"XXA"
+				],
+				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null."
 			},
 			{
 				"field_name": "received_filename",
 				"required": true,
 				"allowed_values": null,
-				"description": "This field is the name of the file when uploaded.",
-				"compat_field_name": "meta_ext_filename"
+				"description": "This field is the name of the file when uploaded."
 			},
 			{
 				"field_name": "data_stream_id",
 				"required": true,
-				"allowed_values": "h1n5",
-				"description": "This field is the identifier for the data stream.",
-				"compat_field_name": "meta_destination_id"
+				"allowed_values": "h5-influenza-vaccination",
+				"description": "This field is the identifier for the data stream."
 			},
 			{
 				"field_name": "data_stream_route",
 				"required": true,
 				"allowed_values": "csv",
-				"description": "This recieved is the route of the data stream.",
-				"compat_field_name": "meta_ext_event"
+				"description": "This recieved is the route of the data stream."
 			},
 			{
 				"field_name": "meta_ext_objectkey",
 				"required": true,
 				"allowed_values": null,
-				"description": "This field is used to track back to the source objectid.",
-				"compat_field_name": null
+				"description": "This field is used to track back to the source objectid."
 			},
 			{
 				"field_name": "meta_ext_file_timestamp",
 				"required": true,
 				"allowed_values": null,
-				"description": "The timestamp on the source for file last modified.",
-				"compat_field_name": null
+				"description": "The timestamp on the source for file last modified."
 			},
 			{
 				"field_name": "meta_username",
 				"required": true,
 				"allowed_values": null,
-				"description": "Username of user or system name who submitted the file.",
-				"compat_field_name": null
+				"description": "Username of user or system name who submitted the file."
 			},
 			{
 				"field_name": "meta_ext_sourceversion",
+				"required": true,
 				"allowed_values": [
+					"V2022-12-31",
 					"V2023-09-01"
 				],
-				"required": true,
 				"description": "Aligns with version of the specification."
 			},
 			{
 				"field_name": "meta_ext_submissionperiod",
-				"allowed_values": null,
 				"required": true,
+				"allowed_values": null,
 				"description": "Submission period for the file submitted."
 			}
 		]


### PR DESCRIPTION
## Updates to the NDLP H5 Flu Vaccine Config
- updated config name to `h5-influenza-vaccination-csv.json`
- updated data_stream_id allowed value to `h5-influenza-vaccination`
- added custom metadata field meta_ext_sourceversion allowed value `V2022-12-31`
- removed all compatible field lines; this config was never a v1 config, so these lines were not needed
- added `XXA` allowed test value to jurisdiction
- added full list of allowed values to data_producer_id