### PR TITLE
H5 flu vax fix for allowed values

### DIFF
--- a/upload-configs/v2/h5-influenza-vaccination-csv.json
+++ b/upload-configs/v2/h5-influenza-vaccination-csv.json
@@ -225,13 +225,17 @@
 			{
 				"field_name": "data_stream_id",
 				"required": true,
-				"allowed_values": "h5-influenza-vaccination",
+				"allowed_values": [
+					"h5-influenza-vaccination"
+				],
 				"description": "This field is the identifier for the data stream."
 			},
 			{
 				"field_name": "data_stream_route",
 				"required": true,
-				"allowed_values": "csv",
+				"allowed_values": [
+					"csv"
+				],
 				"description": "This recieved is the route of the data stream."
 			},
 			{


### PR DESCRIPTION
## Updates to H5 Flu vaccine config
- updated allowed values for data_stream_id and data_stream_route to be included in brackets, in conformance with other config files