### PR TITLE
tidy: use navbar component on index html

### DIFF
--- a/upload-server/internal/ui/index.html
+++ b/upload-server/internal/ui/index.html
@@ -9,10 +9,7 @@
   </head>
 
   <body>
-    <a class="skip-main" href="#main" tabindex="0">Skip to main content</a>
-    <div role="navigation" id="nav" class="nav-container">
-      <a href="/"> <img src="/assets/dex_logo.svg" alt="DEX logo" /> Upload </a>
-    </div>
+    {{template "navbar" .Navbar}}
     <main id="main" class="upload-container">
       <h1>Welcome to DEX Upload</h1>
       <h2>Start the upload process by entering a data stream and route.</h2>
@@ -38,5 +35,4 @@
       </div>
     </main>
   </body>
-  <script src="/assets/banner.js"></script>
 </html>

--- a/upload-server/internal/ui/ui.go
+++ b/upload-server/internal/ui/ui.go
@@ -33,6 +33,7 @@ var usefulFuncs = template.FuncMap{
 	"FixNames": FixNames,
 }
 
+var indexTemplate = template.Must(template.ParseFS(content, "index.html", "components/navbar.html"))
 var manifestTemplate = template.Must(template.New("manifest.tmpl").Funcs(usefulFuncs).ParseFS(content, "manifest.tmpl", "components/navbar.html"))
 var uploadTemplate = template.Must(template.ParseFS(content, "upload.tmpl", "components/navbar.html"))
 
@@ -180,7 +181,14 @@ func GetRouter(uploadUrl string, infoUrl string) *http.ServeMux {
 			return
 		}
 	})
-	router.Handle("/", StaticHandler)
+	router.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		err := indexTemplate.Execute(rw, nil)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+	router.Handle("/assets/", StaticHandler)
 
 	return router
 }


### PR DESCRIPTION
Small cleanup for using the navbar component within the index.html page.  Needed to split the static handler into one that explicitly handles root and one for the rest of the static assets.  The new explicit root handler simply executes the template for index.html.