### PR TITLE
UPLOAD-1706/use env var expantion for config parsing

### DIFF
--- a/upload-configs/v2/ehdi-csv.json
+++ b/upload-configs/v2/ehdi-csv.json
@@ -76,7 +76,7 @@
   "copy_config": {
     "filename_suffix": "upload_id",
     "folder_structure": "date_YYYY_MM_DD",
-    "path_template": "DHDD/EHDI/DEX-{{.Env}}/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}",
+    "path_template": "${EHDI_PATH_TEMPLATE}",
     "targets": [
       "ehdi"
     ]

--- a/upload-configs/v2/eicr-fhir.json
+++ b/upload-configs/v2/eicr-fhir.json
@@ -60,7 +60,7 @@
 	"copy_config": {
 		"filename_suffix": "upload_id",
 		"folder_structure": "date_YYYY_MM_DD",
-		"path_template": "DDTP/eICR Learning Pilot(eICRLRNG)/DEX-{{.Env}}/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}",
+		"path_template": "${EICR_PATH_TEMPLATE}",
 		"targets": [
 			"eicr"
 		]

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -99,9 +99,6 @@ type AppConfig struct {
 	EhdiCheckpointContainer    string `env:"EHDI_CHECKPOINT_CONTAINER_NAME, default=ehdi-checkpoint"`
 	EicrCheckpointContainer    string `env:"EICR_CHECKPOINT_CONTAINER_NAME, default=eicr-checkpoint"`
 
-	// Path templates
-	EhdiPathTemplate string `env:"EHDI_PATH_TEMPLATE, default=DHDD/EHDI/DEX-{{.Env}}/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"`
-
 	Metrics MetricsConfig `env:", prefix=METRICS_"`
 } // .AppConfig
 

--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -99,6 +99,9 @@ type AppConfig struct {
 	EhdiCheckpointContainer    string `env:"EHDI_CHECKPOINT_CONTAINER_NAME, default=ehdi-checkpoint"`
 	EicrCheckpointContainer    string `env:"EICR_CHECKPOINT_CONTAINER_NAME, default=eicr-checkpoint"`
 
+	// Path templates
+	EhdiPathTemplate string `env:"EHDI_PATH_TEMPLATE, default=DHDD/EHDI/DEX-{{.Env}}/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"`
+
 	Metrics MetricsConfig `env:", prefix=METRICS_"`
 } // .AppConfig
 

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -59,7 +59,6 @@ type PathInfo struct {
 	Year     string
 	Month    string
 	Day      string
-	Env      string
 	UploadId string
 	Filename string
 }
@@ -205,7 +204,6 @@ func getDeliveredFilename(ctx context.Context, tuid string, manifest map[string]
 			Day:      strconv.Itoa(t.Day()),
 			Filename: filenameWithoutExtension,
 			UploadId: tuid,
-			Env:      appconfig.LoadedConfig.Environment,
 		}
 		tmpl, err := template.New("path").Parse(c.Copy.PathTemplate)
 		if err != nil {

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -109,8 +109,11 @@ func (c *ConfigCache) GetConfig(ctx context.Context, key string) (*validation.Ma
 		if err != nil {
 			return nil, err
 		}
+
+		// Expand config string to substitute any env var placeholders within.
+		expandedConf := os.ExpandEnv(string(b))
 		mc := &validation.ManifestConfig{}
-		if err := json.Unmarshal(b, mc); err != nil {
+		if err := json.Unmarshal([]byte(expandedConf), mc); err != nil {
 			return nil, err
 		}
 		c.SetConfig(key, mc)


### PR DESCRIPTION
This patch increases the flexibilty of our upload configurations by allowing us to substitute values from environment variables.  This will allow us to configure the template path for delivery destinations on a per-environment level if we so choose.  

For example, if you wanted to follow a template such as `my/destination/subfolder/test/` for lower environments and `my/destination/subfolder/` for prod, you can by setting an environment variable with the template that you want.

This does this by utilizing the `ExpandEnv` function of the golang `os` package.  This function takes a string and looks for placeholder labels and matches them to environment variables.  This is similar to how github action workflow yml files handle their environment and secret substitutions.