### PR TITLE
new ndlp config and allowed spec value

### DIFF
--- a/upload-configs/v1/ndlp-covidallmonthlyvaccination.json
+++ b/upload-configs/v1/ndlp-covidallmonthlyvaccination.json
@@ -13,7 +13,8 @@
             {
                 "field_name": "meta_ext_sourceversion",
                 "allowed_values": [
-                    "V2023-09-01"
+                    "V2023-09-01",
+                    "V2024-09-04"
                 ],
                 "required": true,
                 "description": "Aligns with version of the specification."
@@ -115,7 +116,8 @@
                     "HH2",
                     "HR2",
                     "DV3",
-                    "FD3"
+                    "FD3",
+                    "XXA"
                 ],
                 "required": true,
                 "description": "Drives metrics for vaccine admin progress at entity grouping level."

--- a/upload-configs/v1/ndlp-covidbridgevaccination.json
+++ b/upload-configs/v1/ndlp-covidbridgevaccination.json
@@ -13,7 +13,8 @@
             {
                 "field_name": "meta_ext_sourceversion",
                 "allowed_values": [
-                    "V2023-09-01"
+                    "V2023-09-01",
+                    "V2024-09-04"
                 ],
                 "required": true,
                 "description": "Aligns with version of the specification."
@@ -115,7 +116,8 @@
                     "HH2",
                     "HR2",
                     "DV3",
-                    "FD3"
+                    "FD3",
+                    "XXA"
                 ],
                 "required": true,
                 "description": "Drives metrics for vaccine admin progress at entity grouping level."

--- a/upload-configs/v1/ndlp-genericimmunization.json
+++ b/upload-configs/v1/ndlp-genericimmunization.json
@@ -13,8 +13,6 @@
             {
                 "field_name": "meta_ext_sourceversion",
                 "allowed_values": [
-                    "V2022-12-31",
-                    "V2023-09-01",
                     "V2024-09-04"
                 ],
                 "required": true,
@@ -155,5 +153,5 @@
             "edav"
         ]
     },
-	"compat_config_filename": "influenza-vaccination-csv.json"
+	"compat_config_filename": "generic-immunization-other.json"
 }

--- a/upload-configs/v1/ndlp-routineimmunization.json
+++ b/upload-configs/v1/ndlp-routineimmunization.json
@@ -36,7 +36,8 @@
 				"field_name": "meta_ext_sourceversion",
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"required": true,
 				"description": "Aligns with version of the specification."
@@ -138,7 +139,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"required": true,
 				"description": "Drives metrics for vaccine admin progress at entity grouping level."

--- a/upload-configs/v1/ndlp-rsvprevention.json
+++ b/upload-configs/v1/ndlp-rsvprevention.json
@@ -13,7 +13,8 @@
 			{
 				"field_name": "meta_ext_sourceversion",
 				"allowed_values": [
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"required": true,
 				"description": "Aligns with version of the specification."
@@ -115,7 +116,8 @@
 					"HH2",
 					"HR2",
 					"DV3",
-					"FD3"
+					"FD3",
+					"XXA"
 				],
 				"required": true,
 				"description": "Drives metrics for vaccine admin progress at entity grouping level."

--- a/upload-configs/v2/covid-all-monthly-vaccination-csv.json
+++ b/upload-configs/v2/covid-all-monthly-vaccination-csv.json
@@ -260,7 +260,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},

--- a/upload-configs/v2/covid-bridge-vaccination-csv.json
+++ b/upload-configs/v2/covid-bridge-vaccination-csv.json
@@ -260,7 +260,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},

--- a/upload-configs/v2/generic-immunization-other.json
+++ b/upload-configs/v2/generic-immunization-other.json
@@ -8,7 +8,8 @@
 				"allowed_values": [
 					"IZGW"
 				],
-				"description": "This field is the identifier for the sender of the data."
+				"description": "This field is the identifier for the sender of the data.",
+				"compat_field_name": "meta_ext_source"				
 			},
 			{
 				"field_name": "data_producer_id",
@@ -214,29 +215,33 @@
 					"FD3",
 					"XXA"
 				],
-				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null."
+				"description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null.",
+				"compat_field_name": "meta_ext_entity"				
 			},
 			{
 				"field_name": "received_filename",
 				"required": true,
 				"allowed_values": null,
-				"description": "This field is the name of the file when uploaded."
+				"description": "This field is the name of the file when uploaded.",
+				"compat_field_name": "meta_ext_filename"				
 			},
 			{
 				"field_name": "data_stream_id",
 				"required": true,
 				"allowed_values": [
-					"h5-influenza-vaccination"
+					"generic-immunization"
 				],
-				"description": "This field is the identifier for the data stream."
+				"description": "This field is the identifier for the data stream.",
+				"compat_field_name": "meta_destination_id"				
 			},
 			{
 				"field_name": "data_stream_route",
 				"required": true,
 				"allowed_values": [
-					"csv"
+					"other"
 				],
-				"description": "This recieved is the route of the data stream."
+				"description": "This recieved is the route of the data stream.",
+				"compat_field_name": "meta_ext_event"				
 			},
 			{
 				"field_name": "meta_ext_objectkey",
@@ -261,7 +266,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},

--- a/upload-configs/v2/influenza-vaccination-csv.json
+++ b/upload-configs/v2/influenza-vaccination-csv.json
@@ -260,7 +260,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},

--- a/upload-configs/v2/routine-immunization-other.json
+++ b/upload-configs/v2/routine-immunization-other.json
@@ -260,7 +260,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},

--- a/upload-configs/v2/rsv-prevention-csv.json
+++ b/upload-configs/v2/rsv-prevention-csv.json
@@ -260,7 +260,8 @@
 				"required": true,
 				"allowed_values": [
 					"V2022-12-31",
-					"V2023-09-01"
+					"V2023-09-01",
+					"V2024-09-04"
 				],
 				"description": "Aligns with version of the specification."
 			},


### PR DESCRIPTION
## Updates
- v1 ndlp config updates: added "XXA" test allowed value; added new specification allowed value - flu vax, rsv, covid a, covid b, routine immunization
- v2 ndlp config updates: added new specification allowed value - flu vax, rsv, covid a, covid b, routine immunization

## Deletions
- deleted erroneous named config for generic immunization

## Additions
- v1 ndlp config for generic immunizations
- v2 ndlp config for generic immunizations