### PR TITLE
env var for s3 upload config folder name

### DIFF
--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -89,6 +89,7 @@ type AppConfig struct {
 	// S3
 	S3Connection           *S3StorageConfig `env:", prefix=S3_, noinit"`
 	S3ManifestConfigBucket string           `env:"DEX_MANIFEST_CONFIG_BUCKET_NAME"`
+	S3ManifestConfigFolder string           `env:"DEX_S3_MANIFEST_CONFIG_FOLDER_NAME"`
 	EdavS3Connection       *S3StorageConfig `env:", prefix=EDAV_S3_, noinit"`
 	RoutingS3Connection    *S3StorageConfig `env:", prefix=ROUTING_S3_, noinit"`
 

--- a/upload-server/internal/loaders/s3.go
+++ b/upload-server/internal/loaders/s3.go
@@ -9,12 +9,17 @@ import (
 type S3ConfigLoader struct {
 	Client     *s3.Client
 	BucketName string
+	Folder     string
 }
 
 func (l *S3ConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte, error) {
+	key := path
+	if l.Folder != "" {
+		key = l.Folder + "/" + key
+	}
 	output, err := l.Client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: &l.BucketName,
-		Key:    &path,
+		Key:    &key,
 	})
 	defer output.Body.Close()
 	if err != nil {

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -87,12 +87,17 @@ func InitConfigCache(ctx context.Context, appConfig appconfig.AppConfig) error {
 
 	if appConfig.S3Connection != nil {
 		client, err := stores3.New(ctx, appConfig.S3Connection)
+		bucket := appConfig.S3Connection.BucketName
+		if appConfig.S3ManifestConfigBucket != "" {
+			bucket = appConfig.S3ManifestConfigBucket
+		}
 		if err != nil {
 			return err
 		}
 		Cache.Loader = &loaders.S3ConfigLoader{
 			Client:     client,
-			BucketName: appConfig.S3ManifestConfigBucket,
+			BucketName: bucket,
+			Folder:     appConfig.S3ManifestConfigFolder,
 		}
 	}
 


### PR DESCRIPTION
Adds an app config env var for specifying a folder for the app configs within an S3 bucket.
Also defaults the S3 config loader bucket to the tus bucket, but uses the `DEX_MANIFEST_CONFIG_BUCKET_NAME` env var if it exists.  This allows users to place their upload configs in a separate bucket if they so choose.