### PR TITLE
Updated gh action REF input to pass in correct value

### DIFF
--- a/.github/workflows/tus-upload-server-ci.yml
+++ b/.github/workflows/tus-upload-server-ci.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/remote-cd-trigger-template.yml
     with:
       WORKFLOW: fortify.yml
-      REF: ${{ github.ref_name }}
+      REF: ${{ github.head_ref }}
     secrets: inherit
 
     


### PR DESCRIPTION
github.ref_name resolved to PR number when PR was opened. this change is to resolve to the branch name which is what the fortify workflow requires