### PR TITLE
Quickfix/v1 mainfest translation delivery

### DIFF
--- a/upload-server/clean.sh
+++ b/upload-server/clean.sh
@@ -11,4 +11,6 @@ rm -rf testing/test/uploads
 rm -rf testing/test/dex
 rm -rf testing/test/edav
 rm -rf testing/test/routing
+rm -rf testing/test/ehdi
+rm -rf testing/test/eicr
 rm -rf testing/test/events

--- a/upload-server/clean.sh
+++ b/upload-server/clean.sh
@@ -3,6 +3,9 @@ rm -rf uploads/tus-prefix
 rm -rf uploads/dex
 rm -rf uploads/edav
 rm -rf uploads/routing
+rm -rf uploads/ehdi
+rm -rf uploads/eicr
+rm -rf uploads/events
 rm -rf testing/test/reports
 rm -rf testing/test/uploads
 rm -rf testing/test/dex

--- a/upload-server/internal/loaders/file/file.go
+++ b/upload-server/internal/loaders/file/file.go
@@ -13,8 +13,7 @@ type FileConfigLoader struct {
 	FileSystem fs.FS
 }
 
-func (l *FileConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte, error) {
-
+func (l *FileConfigLoader) LoadConfig(_ context.Context, path string) ([]byte, error) {
 	file, err := l.FileSystem.Open(path)
 	if err != nil {
 		return nil, errors.Join(err, validation.ErrNotFound)

--- a/upload-server/internal/loaders/s3.go
+++ b/upload-server/internal/loaders/s3.go
@@ -21,6 +21,8 @@ func (l *S3ConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte, e
 		Bucket: &l.BucketName,
 		Key:    &key,
 	})
+	// TODO wrap err in validation.ErrNotFound if didn't find the object
+	// TODO handle nil pointer in if body is nil
 	defer output.Body.Close()
 	if err != nil {
 		return nil, err

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -142,18 +142,27 @@ func GetConfigFromManifest(ctx context.Context, manifest handler.MetaData) (*val
 		return nil, err
 	}
 	config, err := Cache.GetConfig(ctx, path)
-	// TODO fallback to v1 if err is validation.ErrNotFound
 	if err != nil {
+		if errors.Is(err, validation.ErrNotFound) && GetVersion(manifest) == "2.0" {
+			// Fall back to v1 config
+			locBuilder, _ := registeredVersions["1.0"]
+			loc, err := locBuilder(manifest)
+			if err != nil {
+				return nil, err
+			}
+			config, err = Cache.GetConfig(ctx, loc.Path())
+			if err != nil {
+				return nil, err
+			}
+			return config, nil
+		}
 		return nil, err
 	}
 	return config, nil
 }
 
 func GetConfigIdentifierByVersion(manifest handler.MetaData) (string, error) {
-	version := manifest["version"]
-	if version == "" {
-		version = "1.0"
-	}
+	version := GetVersion(manifest)
 	configLocationBuilder, ok := registeredVersions[version]
 	if !ok {
 		return "", fmt.Errorf("unsupported version %s %w", version, validation.ErrFailure)
@@ -163,6 +172,14 @@ func GetConfigIdentifierByVersion(manifest handler.MetaData) (string, error) {
 		return "", err
 	}
 	return configLoc.Path(), nil
+}
+
+func GetVersion(manifest handler.MetaData) string {
+	version := manifest["version"]
+	if version == "" {
+		return "1.0"
+	}
+	return version
 }
 
 func GetFilenamePrefix(ctx context.Context, manifest handler.MetaData) (string, error) {

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -142,6 +142,7 @@ func GetConfigFromManifest(ctx context.Context, manifest handler.MetaData) (*val
 		return nil, err
 	}
 	config, err := Cache.GetConfig(ctx, path)
+	// TODO fallback to v1 if err is validation.ErrNotFound
 	if err != nil {
 		return nil, err
 	}

--- a/upload-server/internal/postprocessing/merge.go
+++ b/upload-server/internal/postprocessing/merge.go
@@ -19,11 +19,7 @@ func RouteAndDeliverHook() func(handler.HookEvent, hooks.HookResponse) (hooks.Ho
 		}
 
 		// Load config from metadata.
-		path, err := metadata.GetConfigIdentifierByVersion(meta)
-		if err != nil {
-			return resp, err
-		}
-		config, err := metadata.Cache.GetConfig(ctx, path)
+		config, err := metadata.GetConfigFromManifest(ctx, meta)
 		if err != nil {
 			return resp, err
 		}


### PR DESCRIPTION
Handles edge case where file with v1 manifest is uploaded, and post finish hook tries to find upload config with same name but for v2.  If it doesn't find a v2 config, it falls back to v1.  If it doesn't find v1, it returns an error to the user.

For context, it tries to find a v2 config when a v1 manifest is used because the v1 manifest is hydrated with v2 manifest fields, including `verstion: 2.0`.  So when the metadata gets read in post finish, it appears as v2.

There are probably more long term fixes for this edge case, but we want to at some point soon remove this hydration behavior completely.