### PR TITLE
Quickfix/s3 health check improvement

### DIFF
--- a/upload-server/cmd/cli/datastore.go
+++ b/upload-server/cmd/cli/datastore.go
@@ -55,7 +55,6 @@ func GetDataStore(ctx context.Context, appConfig appconfig.AppConfig) (handlertu
 		store.Container = appConfig.AzureUploadContainer
 		return store, hc, nil
 	} // .if
-
 	if appConfig.S3Connection != nil {
 		client, err := stores3.New(ctx, appConfig.S3Connection)
 		if err != nil {

--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"testing"
 	"time"
 
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
@@ -27,6 +28,13 @@ import (
 const appMainExitCode = 1
 
 func init() {
+
+	if !testing.Testing() {
+		if err := cli.ParseFlags(); err != nil {
+			slog.Error("error starting app, error parsing cli flags", "error", err)
+			os.Exit(appMainExitCode)
+		}
+	}
 
 	if cli.Flags.AppConfigPath != "" {
 		slog.Info("Loading environment from", "file", cli.Flags.AppConfigPath)

--- a/upload-server/docker-compose.minio.yml
+++ b/upload-server/docker-compose.minio.yml
@@ -15,7 +15,7 @@ services:
       - AWS_REGION=us-east-1
       - AWS_ACCESS_KEY_ID=minioadmin
       - AWS_SECRET_ACCESS_KEY=minioadmin
-      - DEX_MANIFEST_CONFIG_BUCKET_NAME=upload-configs
+      - DEX_MANIFEST_CONFIG_FOLDER_NAME=upload-configs
     depends_on:
       - minio
       - cache

--- a/upload-server/internal/delivery/s3.go
+++ b/upload-server/internal/delivery/s3.go
@@ -83,19 +83,20 @@ func (ss *S3Source) GetMetadata(ctx context.Context, tuid string) (map[string]st
 	return output.Metadata, nil
 }
 
-func (sd *S3Source) Health(ctx context.Context) (rsp models.ServiceHealthResp) {
-	rsp.Service = "S3 source"
+func (ss *S3Source) Health(ctx context.Context) (rsp models.ServiceHealthResp) {
+	rsp.Service = "S3 source " + ss.BucketName
 	rsp.Status = models.STATUS_UP
 
-	if sd.FromClient == nil {
+	if ss.FromClient == nil {
 		// Running in azure, but deliverer not set up.
 		rsp.Status = models.STATUS_DOWN
 		rsp.HealthIssue = "S3 source not configured"
 	}
 
-	_, err := sd.FromClient.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
-		Bucket: &sd.BucketName,
+	_, err := ss.FromClient.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: &ss.BucketName,
 	})
+
 	if err != nil {
 		rsp.Status = models.STATUS_DOWN
 		rsp.HealthIssue = err.Error()
@@ -141,7 +142,7 @@ func (sd *S3Destination) Health(ctx context.Context) (rsp models.ServiceHealthRe
 		rsp.HealthIssue = "S3 deliverer target " + sd.Target + " not configured"
 	}
 
-	_, err := sd.ToClient.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
+	_, err := sd.ToClient.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: &sd.BucketName,
 	})
 	if err != nil {

--- a/upload-server/internal/loaders/s3.go
+++ b/upload-server/internal/loaders/s3.go
@@ -25,7 +25,7 @@ func (l *S3ConfigLoader) LoadConfig(ctx context.Context, path string) ([]byte, e
 		Key:    &key,
 	})
 	defer func() {
-		if output.Body != nil {
+		if output != nil && output.Body != nil {
 			output.Body.Close()
 		}
 	}()

--- a/upload-server/internal/stores3/s3healthcheck.go
+++ b/upload-server/internal/stores3/s3healthcheck.go
@@ -21,7 +21,7 @@ func (c *S3HealthCheck) Health(ctx context.Context) models.ServiceHealthResp {
 		return shr
 	}
 
-	_, err := c.Client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
+	_, err := c.Client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: &c.BucketName,
 	})
 


### PR DESCRIPTION
This patch is mainly to fix the health checks that the server performs against S3 buckets for tus, delivery source, and delivery destination.  Currently, the server uses the `GetBucketLocation` function as a mechanism for verifying the connection.  However, the `HeadBucket` operation is apparently the more appropriate one to use for this purpose.  See https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.HeadBucket

Additionally, this patch re-adds the `ParseFlags` function call that was removed in a previous commit.