### PR TITLE
Fixing the default validations for dextesting/testevent1

### DIFF
--- a/tests/bad-uploader/config.go
+++ b/tests/bad-uploader/config.go
@@ -38,6 +38,7 @@ var (
 		"data_producer_id":  "dex simulation harness",
 		"jurisdiction":      "test",
 	}
+	manifestTargets = []string{"edav", "eicr", "ehdi", "ncird"}
 
 	testcase TestCase
 	cases    TestCases
@@ -236,7 +237,7 @@ func init() {
 			Size:                    size,
 			Manifest:                manifest,
 			TimeLimit:               Duration(10 * time.Second),
-			ExpectedDeliveryTargets: []string{"edav", "eicr", "ehdi", "ncird"},
+			ExpectedDeliveryTargets: manifestTargets,
 		}
 		if templatePath != "" {
 			testcase.TemplateFile = templatePath

--- a/tests/bad-uploader/config.go
+++ b/tests/bad-uploader/config.go
@@ -236,7 +236,7 @@ func init() {
 			Size:                    size,
 			Manifest:                manifest,
 			TimeLimit:               Duration(10 * time.Second),
-			ExpectedDeliveryTargets: []string{"edav"},
+			ExpectedDeliveryTargets: []string{"edav", "eicr", "ehdi", "ncird"},
 		}
 		if templatePath != "" {
 			testcase.TemplateFile = templatePath


### PR DESCRIPTION
- Fixing the validations that bad uploader is doing for the default configuration.  
- Adding in extra download targets for the default.  
- Put the targets in `manifestTargets` that lives close to the `manifest` object to have it a little bit easier to see them both.