### PR TITLE
Upload 1747/cloud agnostic e2e tests

### DIFF
--- a/tests/smoke/kotlin/README.md
+++ b/tests/smoke/kotlin/README.md
@@ -9,7 +9,7 @@ The following tools need to be installed on your machine:
 - [Gradle](https://gradle.org/install/)
 
 > [!TIP]
-> For Windows users, the gradlew batch file in the repo can be used to execute gradle commands as long as Gradle is installed.
+> For Windows users, the `gradlew` batch file in the repo can be used to execute gradle commands as long as Gradle is installed.
 
 ### Install Gradle Dependencies
 
@@ -26,7 +26,7 @@ The following are the currently configured environment variables that can be set
 
 | Environment Variable | Required? | Description                                      |
 | ---------------------| --------- | -------------------------------------------------|
-| environment          | Yes       | Environment to target (LOCAL, DEV, TEST, STAGE)
+| environment          | Yes       | Environment to target (`LOCAL`, `DEV`, `TEST`, `STAGE`)
 | upload.url           | Yes       | URL of the upload API
 | ps.api.url           | Yes       | URL for Processing Status API  
 | sams.username        | No        | SAMS username for authentication (if needed)
@@ -57,7 +57,7 @@ The following are some examples of test run commands.
 > The `--tests` parameter lets you select only a specific test file to run or a specific test within a file.
 
 > [!TIP]
-> The --rerun command may be needed in order to force tests to rerun, otherwise tests may be skipped if there are no changes.
+> The `--rerun` command may be needed in order to force tests to rerun, otherwise tests may be skipped if there are no changes.
 
 ##### Run All Tests
 

--- a/tests/smoke/kotlin/local.properties-example
+++ b/tests/smoke/kotlin/local.properties-example
@@ -1,4 +1,5 @@
 #dev
+environment=DEV
 upload.url=https://apidev.cdc.gov
 ps.api.url=https://dex-dev-svc.cdc.gov
 sams.username=
@@ -11,6 +12,7 @@ azure.client.secret=
 azure.tenant.id=
 
 # tst
+environment=TEST
 upload.url=https://apitst.cdc.gov
 ps.api.url=https://dex-tst-svc.cdc.gov
 sams.username=
@@ -23,6 +25,7 @@ azure.client.secret=
 azure.tenant.id=
 
 # stg
+environment=STAGE
 upload.url=https://apistg.cdc.gov
 ps.api.url=https://dex-stg-svc.cdc.gov
 sams.username=

--- a/tests/smoke/kotlin/local.properties-example
+++ b/tests/smoke/kotlin/local.properties-example
@@ -1,15 +1,17 @@
+#local
+environment=LOCAL
+upload.url=http://localhost:8080
+ps.api.url=http://localhost:8080
+sams.username=
+sams.password=
+
 #dev
 environment=DEV
 upload.url=https://apidev.cdc.gov
 ps.api.url=https://dex-dev-svc.cdc.gov
 sams.username=
 sams.password=
-dex.storage.connection.string=
-edav.storage.account.name=
-routing.storage.connection.string=
-azure.client.id=
-azure.client.secret=
-azure.tenant.id=
+
 
 # tst
 environment=TEST
@@ -17,12 +19,7 @@ upload.url=https://apitst.cdc.gov
 ps.api.url=https://dex-tst-svc.cdc.gov
 sams.username=
 sams.password=
-dex.storage.connection.string=
-edav.storage.account.name=
-routing.storage.connection.string=
-azure.client.id=
-azure.client.secret=
-azure.tenant.id=
+
 
 # stg
 environment=STAGE
@@ -30,9 +27,3 @@ upload.url=https://apistg.cdc.gov
 ps.api.url=https://dex-stg-svc.cdc.gov
 sams.username=
 sams.password=
-dex.storage.connection.string=
-edav.storage.account.name=
-routing.storage.connection.string=
-azure.client.id=
-azure.client.secret=
-azure.tenant.id=

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -51,8 +51,8 @@ class FileCopy {
         dataProvider = "validManifestAllProvider",
         dataProviderClass = DataProvider::class
     )
-    fun shouldUploadFile(manifest: HashMap<String, String>) {
-        val uid = uploadClient.uploadFile(testFile, manifest)
+    fun shouldUploadFile(case: TestCase) {
+        val uid = uploadClient.uploadFile(testFile, case.manifest)
             ?: throw TestNGException("Error uploading file ${testFile.name}")
         testContext.setAttribute("uploadId", uid)
         Thread.sleep(2000)
@@ -67,11 +67,11 @@ class FileCopy {
         Assert.assertEquals(uploadBlob.properties.blobSize, testFile.length())
 
         // Next, check that the file arrived in destination storage.
-        val config = loadUploadConfig(dexBlobClient, manifest)
+        val config = loadUploadConfig(dexBlobClient, case.manifest)
         val filenameSuffix = Filename.getFilenameSuffix(config.copyConfig, uid)
         val expectedFilename = "${
-            Metadata.getFilePrefix(config.copyConfig, manifest)
-        }${Metadata.getFilename(manifest)}${filenameSuffix}${testFile.extension}"
+            Metadata.getFilePrefix(config.copyConfig, case.manifest)
+        }${Metadata.getFilename(case.manifest)}${filenameSuffix}${testFile.extension}"
         var expectedBlobClient: BlobClient?
 
         if (config.copyConfig.targets.contains("edav")) {

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -10,7 +10,8 @@ import util.ConfigLoader.Companion.loadUploadConfig
 import util.DataProvider
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util.TimeZone
 import kotlin.collections.HashMap
 
 
@@ -76,7 +77,9 @@ class FileCopy {
         val actualDeliveryNames = uploadInfo.deliveries?.map{ it.name }?.sorted()
         Assert.assertEquals(actualDeliveryNames, expectedDeliveryNames, "Actual delivery targets do not match expected targets")
 
-        val currentDateTime = LocalDateTime.now()
+    
+        val currentDateTime = ZonedDateTime.now(TimeZone.getTimeZone("GMT").toZoneId())
+        
         uploadInfo.deliveries?.forEach { delivery ->
             Assert.assertEquals(delivery.status, "SUCCESS") // remove the assertion above?
             val actualLocation = URLDecoder.decode(delivery.location, StandardCharsets.UTF_8.toString())

--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -10,7 +10,7 @@ import util.ConfigLoader.Companion.loadUploadConfig
 import util.DataProvider
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import java.time.LocalDate
+import java.time.LocalDateTime
 import kotlin.collections.HashMap
 
 
@@ -33,6 +33,7 @@ class FileCopy {
     private val edavContainerClient = edavBlobClient.getBlobContainerClient(Constants.EDAV_UPLOAD_CONTAINER_NAME)
     private val routingContainerClient =
         routingBlobClient.getBlobContainerClient(Constants.ROUTING_UPLOAD_CONTAINER_NAME)
+    private val environment = EnvConfig.ENVIRONMENT
     private lateinit var authToken: String
     private lateinit var testContext: ITestContext
     private lateinit var uploadClient: UploadClient
@@ -57,7 +58,7 @@ class FileCopy {
         val uid = uploadClient.uploadFile(testFile, case.manifest)
             ?: throw TestNGException("Error uploading file ${testFile.name}")
         testContext.setAttribute("uploadId", uid)
-        Thread.sleep(5000)
+        Thread.sleep(2000)
         val uploadInfo = dexUploadClient.getFileInfo(uid, authToken)
 
         // Check File Info
@@ -75,55 +76,24 @@ class FileCopy {
         val actualDeliveryNames = uploadInfo.deliveries?.map{ it.name }?.sorted()
         Assert.assertEquals(actualDeliveryNames, expectedDeliveryNames, "Actual delivery targets do not match expected targets")
 
-        val currentDate = LocalDate.now()
+        val currentDateTime = LocalDateTime.now()
         uploadInfo.deliveries?.forEach { delivery ->
             Assert.assertEquals(delivery.status, "SUCCESS") // remove the assertion above?
             val actualLocation = URLDecoder.decode(delivery.location, StandardCharsets.UTF_8.toString())
-            val locationPattern = case.deliveryTargets?.find{ it.name == delivery.name}?.pathTemplate
-            val expectedLocation = locationPattern
-                // This feels hacky, but it works... no logic here to ensure that the
-                // locationPattern has all of these tokens to replace.
+            val pattern = case.deliveryTargets?.find{ it.name == delivery.name}?.pathTemplate?.get(environment)
+
+            val expectedLocation = pattern
                 ?.replace("{dataStream}", case.manifest["data_stream_id"].toString())
                 ?.replace("{route}", case.manifest["data_stream_route"].toString())
-                ?.replace("{year}", currentDate.year.toString() )
-                ?.replace("{month}", String.format("%02d", currentDate.monthValue) )
-                ?.replace("{day}", String.format("%02d", currentDate.dayOfMonth) )
+                ?.replace("{year}", currentDateTime.year.toString() )
+                ?.replace("{month}", String.format("%02d", currentDateTime.monthValue) )
+                ?.replace("{day}", String.format("%02d", currentDateTime.dayOfMonth) )
+                ?.replace("{hour}", String.format("%02d", currentDateTime.hour) )
                 ?.replace("{filename}", case.manifest["received_filename"].toString())
                 ?.replace("{uploadId}",uid)
             Assert.assertTrue(actualLocation.endsWith(expectedLocation.toString()), "Actual location ($actualLocation) does not end with the expected path: $expectedLocation")
             Assert.assertEquals(delivery.issues, null)
         }
-    //
-//        // First, check bulk upload and .info file.
-//        val uploadBlob = bulkUploadsContainerClient.getBlobClient("${Constants.TUS_PREFIX_DIRECTORY_NAME}/$uid")
-//        val uploadInfoBlob =
-//            bulkUploadsContainerClient.getBlobClient("${Constants.TUS_PREFIX_DIRECTORY_NAME}/$uid.info")
-//
-//        Assert.assertTrue(uploadBlob.exists())
-//        Assert.assertTrue(uploadInfoBlob.exists())
-//        Assert.assertEquals(uploadBlob.properties.blobSize, testFile.length())
-//
-//        // Next, check that the file arrived in destination storage.
-//        val config = loadUploadConfig(dexBlobClient, case.manifest)
-//        val filenameSuffix = Filename.getFilenameSuffix(config.copyConfig, uid)
-//        val expectedFilename = "${
-//            Metadata.getFilePrefix(config.copyConfig, case.manifest)
-//        }${Metadata.getFilename(case.manifest)}${filenameSuffix}${testFile.extension}"
-//        var expectedBlobClient: BlobClient?
-//
-//        if (config.copyConfig.targets.contains("edav")) {
-//            expectedBlobClient = edavContainerClient.getBlobClient(expectedFilename)
-//
-//            Assert.assertNotNull(expectedBlobClient)
-//            Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
-//        }
-//
-//        if (config.copyConfig.targets.contains("routing")) {
-//            expectedBlobClient = routingContainerClient.getBlobClient(expectedFilename)
-//
-//            Assert.assertNotNull(expectedBlobClient)
-//            Assert.assertEquals(expectedBlobClient!!.properties.blobSize, testFile.length())
-//        }
     }
 
     @Test(

--- a/tests/smoke/kotlin/src/test/kotlin/ProcStat.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/ProcStat.kt
@@ -158,18 +158,11 @@ class ProcStat {
                     assertNotNull(destinationName, "Destination name is missing for $schemaName")
                     log.info("Blob File Copy - Source URL: $sourceUrl, Destination URL: $destinationUrl")
 
-//                    val expectedDestinations = config.copyConfig.targets
+                    val expectedDestinations = case.deliveryTargets?.map{ it.name }?.sorted()
 
-                    val expectedDestinations = case.deliveryTargets!!.map{ it.name }.sorted()
-
-//                    val actualDestination = expectedDestinations?.any { expectedDest ->
-//                        destinationName?.trim()?.equals(expectedDest.trim(), ignoreCase = true) ?: false
-//                    }
-                    assertTrue(expectedDestinations.contains(destinationName), "Actual destination $destinationName is not in expected target destinations ${expectedDestinations.toString()}")
-//                    assertTrue(
-//                        actualDestination?,
-//                        "None of the expected destinations ('${expectedDestinations.joinToString(", ")}') were found in the response. Found: $destinationName"
-//                    )
+                    if(expectedDestinations != null){
+                        assertTrue(expectedDestinations.contains(destinationName), "Actual destination $destinationName is not in expected target destinations ${expectedDestinations.toString()}")
+                    }
                 }
 
                 else -> {

--- a/tests/smoke/kotlin/src/test/kotlin/model/FileDelivery.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/model/FileDelivery.kt
@@ -7,5 +7,5 @@ data class FileDelivery(
     val name: String,
     val location: String,
     @get:JsonProperty("delivered_at") val deliveredAt: String,
-    val issues: List<String>?
+    val issues: List<HashMap<String, String>>?
 )

--- a/tests/smoke/kotlin/src/test/kotlin/model/InfoResponse.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/model/InfoResponse.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class InfoResponse(
-    val manifest: HashMap<String, String>,
+    @get:JsonProperty("manifest") val manifest: HashMap<String, String>,
     @get:JsonProperty("file_info") val fileInfo: FileInfo,
     @get:JsonProperty("upload_status") val uploadStatus: UploadStatus,
     @get:JsonProperty("deliveries") val deliveries: List<FileDelivery>?

--- a/tests/smoke/kotlin/src/test/kotlin/util/ConfigLoader.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/ConfigLoader.kt
@@ -21,7 +21,7 @@ class ConfigLoader {
             }
         }
 
-        fun loadUploadConfig(dexBlobClient: BlobServiceClient, manifest: HashMap<String, String>): UploadConfig {
+        fun loadUploadConfig(dexBlobClient: BlobServiceClient, manifest: Map<String, String>): UploadConfig {
             val versionFolder = when (manifest["version"]) {
                 "2.0" -> "v2"
                 else -> "v1"

--- a/tests/smoke/kotlin/src/test/kotlin/util/Constants.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/Constants.kt
@@ -1,5 +1,9 @@
 package util
 
+enum class Environment(val env: String) {
+    LOCAL("LOCAL"), DEV("DEV"), TEST("TEST"), STAGE("STAGE")
+}
+
 class Constants {
     companion object {
         const val TEST_DESTINATION = "dextesting"

--- a/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
@@ -107,5 +107,5 @@ data class TestCase(
 
 data class Target(
     @JsonProperty("name") val name: String,
-    @JsonProperty("path_template") val pathTemplate: Map<String, String>
+    @JsonProperty("path_template") val pathTemplate: Map<Environment, String>
 )

--- a/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
@@ -107,5 +107,5 @@ data class TestCase(
 
 data class Target(
     @JsonProperty("name") val name: String,
-    @JsonProperty("path_template") val pathTemplate: String
+    @JsonProperty("path_template") val pathTemplate: Map<String, String>
 )

--- a/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/DataProvider.kt
@@ -102,7 +102,7 @@ class DataProvider {
 
 data class TestCase(
     @JsonProperty("manifest")val manifest: Map<String, String>,
-    @JsonProperty("delivery_targets") val deliveryTargets: List<Target>
+    @JsonProperty("delivery_targets") val deliveryTargets: List<Target>?
 )
 
 data class Target(

--- a/tests/smoke/kotlin/src/test/kotlin/util/EnvConfig.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/EnvConfig.kt
@@ -9,6 +9,7 @@ class EnvConfig {
         private val properties = if (propFile.exists()) Properties().apply {
             load(File("local.properties").inputStream())
         } else null
+        val ENVIRONMENT: String = properties?.getProperty("environment") ?: System.getenv("ENVIRONMENT")
         val UPLOAD_URL: String = properties?.getProperty("upload.url") ?: System.getenv("UPLOAD_URL")
         val PROC_STAT_URL: String = properties?.getProperty("ps.api.url") ?: System.getenv("PS_API_URL")
         val SAMS_USERNAME: String = properties?.getProperty("sams.username") ?: System.getenv("SAMS_USERNAME")

--- a/tests/smoke/kotlin/src/test/kotlin/util/EnvConfig.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/EnvConfig.kt
@@ -9,16 +9,10 @@ class EnvConfig {
         private val properties = if (propFile.exists()) Properties().apply {
             load(File("local.properties").inputStream())
         } else null
-        val ENVIRONMENT: String = properties?.getProperty("environment") ?: System.getenv("ENVIRONMENT")
+        public final val ENVIRONMENT: Environment = Environment.valueOf(properties?.getProperty("environment") ?: System.getenv("ENVIRONMENT"))
         val UPLOAD_URL: String = properties?.getProperty("upload.url") ?: System.getenv("UPLOAD_URL")
         val PROC_STAT_URL: String = properties?.getProperty("ps.api.url") ?: System.getenv("PS_API_URL")
         val SAMS_USERNAME: String = properties?.getProperty("sams.username") ?: System.getenv("SAMS_USERNAME")
         val SAMS_PASSWORD: String = properties?.getProperty("sams.password") ?: System.getenv("SAMS_PASSWORD")
-        val DEX_STORAGE_CONNECTION_STRING: String = properties?.getProperty("dex.storage.connection.string") ?: System.getenv("DEX_STORAGE_CONNECTION_STRING")
-        val EDAV_STORAGE_ACCOUNT_NAME: String = properties?.getProperty("edav.storage.account.name") ?: System.getenv("EDAV_STORAGE_ACCOUNT_NAME")
-        val ROUTING_STORAGE_CONNECTION_STRING: String = properties?.getProperty("routing.storage.connection.string") ?: System.getenv("ROUTING_STORAGE_CONNECTION_STRING")
-        val AZURE_CLIENT_ID: String = properties?.getProperty("azure.client.id") ?: System.getenv("AZURE_CLIENT_ID")
-        val AZURE_CLIENT_SECRET: String = properties?.getProperty("azure.client.secret") ?: System.getenv("AZURE_CLIENT_SECRET")
-        val AZURE_TENANT_ID: String = properties?.getProperty("azure.tenant.id") ?: System.getenv("AZURE_TENANT_ID")
     }
 }

--- a/tests/smoke/kotlin/src/test/kotlin/util/Metadata.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/util/Metadata.kt
@@ -43,7 +43,7 @@ class Metadata {
             return prefix
         }
 
-        fun getFilePrefix(copyConfig: CopyConfig, manifest: HashMap<String, String>): String {
+        fun getFilePrefix(copyConfig: CopyConfig, manifest: Map<String, String>): String {
             var prefix = "${getUseCaseFromManifest(manifest)}/"
 
             if (copyConfig.folderStructure == "date_YYYY_MM_DD") {
@@ -79,7 +79,7 @@ class Metadata {
             }
         }
 
-        fun getFilename(manifest: HashMap<String, String>): String {
+        fun getFilename(manifest: Map<String, String>): String {
             val filenameKeys = arrayOf("received_filename", "meta_ext_filename", "filename", "original_filename")
 
             return manifest.entries.first { filenameKeys.contains(it.key) }.value

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v1.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v1.json
@@ -1,7 +1,9 @@
 [
   {
-    "meta_destination_id": "dextesting",
-    "meta_ext_event": "testevent1",
-    "filename": "dex-smoke-test"
+    "manifest": {
+      "meta_destination_id": "dextesting",
+      "meta_ext_event": "testevent1",
+      "filename": "dex-smoke-test"
+    }
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -12,19 +12,19 @@
     "delivery_targets": [
       {
         "name": "edav",
-        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
       },
       {
         "name": "ncird",
-        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
       },
       {
         "name": "ehdi",
-        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
       },
       {
         "name": "eicr",
-        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
       }
     ]
   }

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -1,111 +1,19 @@
 [
   {
-    "version": "2.0",
-    "data_stream_id": "covid-all-monthly-vaccination",
-    "data_stream_route": "csv",
-    "received_filename": "dex-smoke-test",
-    "jurisdiction": "XXA",
-    "data_producer_id": "XXA",
-    "sender_id": "IZGW",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_submissionperiod": "smoke submission period",
-    "meta_ext_sourceversion": "V2022-12-31",
-    "meta_username": "test-username"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "influenza-vaccination",
-    "data_stream_route": "csv",
-    "received_filename": "dex-smoke-test",
-    "jurisdiction": "XXA",
-    "data_producer_id": "XXA",
-    "sender_id": "IZGW",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_submissionperiod": "smoke submission period",
-    "meta_ext_sourceversion": "V2022-12-31",
-    "meta_username": "test-username"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "routine-immunization",
-    "data_stream_route": "other",
-    "received_filename": "dex-smoke-test",
-    "jurisdiction": "XXA",
-    "data_producer_id": "XXA",
-    "sender_id": "IZGW",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_submissionperiod": "smoke submission period",
-    "meta_ext_sourceversion": "V2022-12-31",
-    "meta_username": "test-username"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "rsv-prevention",
-    "data_stream_route": "csv",
-    "received_filename": "dex-smoke-test",
-    "jurisdiction": "XXA",
-    "data_producer_id": "XXA",
-    "sender_id": "IZGW",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_submissionperiod": "smoke submission period",
-    "meta_ext_sourceversion": "V2022-12-31",
-    "meta_username": "test-username"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "eicr",
-    "data_stream_route": "fhir",
-    "sender_id": "APHL",
-    "data_producer_id": "test-producer-id",
-    "jurisdiction": "test-jurisdiction",
-    "received_filename": "dex-smoke-test",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_file_timestamp": "test-file-timestamp"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "ehdi",
-    "data_stream_route": "csv",
-    "received_filename": "dex-smoke-test",
-    "jurisdiction": "RI",
-    "data_producer_id": "RI-PHA",
-    "sender_id": "RI-PHA",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_file_timestamp": "test-timestamp",
-    "meta_ext_uploadid": "test-upload-id",
-    "meta_ext_source": "test-src",
-    "meta_ext_filestatus": "test-file-status"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "pulsenet",
-    "data_stream_route": "localsequencefile",
-    "received_filename": "dex-smoke-test",
-    "sender_id" : "PulseNet-App",
-    "data_producer_id": "test-producer-id",
-    "jurisdiction": "test-jurisdiction"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "dextesting",
-    "data_stream_route": "testevent1",
-    "received_filename": "dex-smoke-test",
-    "sender_id" : "test sender",
-    "data_producer_id": "test-producer-id",
-    "jurisdiction": "test-jurisdiction"
-  },
-  {
-    "version": "2.0",
-    "data_stream_id": "generic-immunization",
-    "data_stream_route": "csv",
-    "sender_id": "IZGW",
-    "data_producer_id": "XXA",
-    "jurisdiction": "XXA",
-    "received_filename": "dex-smoke-test",
-    "meta_ext_objectkey": "test-obj-key",
-    "meta_ext_file_timestamp": "test-file-timestamp",
-    "meta_username": "test-user",
-    "meta_ext_sourceversion": "V2024-09-04",
-    "meta_ext_submissionperiod":"test-submissionperiod"
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "dextesting",
+      "data_stream_route": "testevent1",
+      "received_filename": "dex-smoke-test",
+      "sender_id" : "test sender",
+      "data_producer_id": "test-producer-id",
+      "jurisdiction": "test-jurisdiction"
+    },
+    "delivery_targets": [
+      {
+        "name": "edav",
+        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+      }
+    ]
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -43,5 +43,201 @@
         }
       }
     ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "covid-all-monthly-vaccination",
+      "data_stream_route": "csv",
+      "received_filename": "dex-smoke-test",
+      "jurisdiction": "XXA",
+      "data_producer_id": "XXA",
+      "sender_id": "IZGW",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_submissionperiod": "smoke submission period",
+      "meta_ext_sourceversion": "V2022-12-31",
+      "meta_username": "test-username"
+    },
+    "delivery_targets": [
+      {
+        "name": "ncird",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "influenza-vaccination",
+      "data_stream_route": "csv",
+      "received_filename": "dex-smoke-test",
+      "jurisdiction": "XXA",
+      "data_producer_id": "XXA",
+      "sender_id": "IZGW",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_submissionperiod": "smoke submission period",
+      "meta_ext_sourceversion": "V2022-12-31",
+      "meta_username": "test-username"
+    },
+    "delivery_targets": [
+      {
+        "name": "ncird",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "routine-immunization",
+      "data_stream_route": "other",
+      "received_filename": "dex-smoke-test",
+      "jurisdiction": "XXA",
+      "data_producer_id": "XXA",
+      "sender_id": "IZGW",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_submissionperiod": "smoke submission period",
+      "meta_ext_sourceversion": "V2022-12-31",
+      "meta_username": "test-username"
+      },
+    "delivery_targets": [
+      {
+        "name": "ncird",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/dex-test/routine-immunization-zip/{year}/{month}/{day}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "rsv-prevention",
+      "data_stream_route": "csv",
+      "received_filename": "dex-smoke-test",
+      "jurisdiction": "XXA",
+      "data_producer_id": "XXA",
+      "sender_id": "IZGW",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_submissionperiod": "smoke submission period",
+      "meta_ext_sourceversion": "V2022-12-31",
+      "meta_username": "test-username"
+    },
+    "delivery_targets": [
+      {
+        "name": "ncird",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "eicr",
+      "data_stream_route": "fhir",
+      "sender_id": "APHL",
+      "data_producer_id": "test-producer-id",
+      "jurisdiction": "test-jurisdiction",
+      "received_filename": "dex-smoke-test",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_file_timestamp": "test-file-timestamp"
+    },
+    "delivery_targets": [
+      {
+        "name": "eicr",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "ehdi",
+      "data_stream_route": "csv",
+      "received_filename": "dex-smoke-test",
+      "jurisdiction": "RI",
+      "data_producer_id": "RI-PHA",
+      "sender_id": "RI-PHA",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_file_timestamp": "test-timestamp",
+      "meta_ext_uploadid": "test-upload-id",
+      "meta_ext_source": "test-src",
+      "meta_ext_filestatus": "test-file-status"
+    },
+    "delivery_targets": [
+      {
+        "name": "ehdi",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/ddnid-ncbddd/DHDD/EHDI/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "pulsenet",
+      "data_stream_route": "localsequencefile",
+      "received_filename": "dex-smoke-test",
+      "sender_id": "PulseNet-App",
+      "data_producer_id": "test-producer-id",
+      "jurisdiction": "test-jurisdiction"
+    },
+    "delivery_targets": [
+      {
+        "name": "edav",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/upload/{dataStream}-{route}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
+  },
+  {
+    "manifest": {
+      "version": "2.0",
+      "data_stream_id": "generic-immunization",
+      "data_stream_route": "csv",
+      "sender_id": "IZGW",
+      "data_producer_id": "XXA",
+      "jurisdiction": "XXA",
+      "received_filename": "dex-smoke-test",
+      "meta_ext_objectkey": "test-obj-key",
+      "meta_ext_file_timestamp": "test-file-timestamp",
+      "meta_username": "test-user",
+      "meta_ext_sourceversion": "V2024-09-04",
+      "meta_ext_submissionperiod": "test-submissionperiod"
+    },
+    "delivery_targets": [
+      {
+        "name": "ncird",
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/{dataStream}-other/{year}/{month}/{day}/{filename}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
+      }
+    ]
   }
 ]

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -13,6 +13,18 @@
       {
         "name": "edav",
         "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+      },
+      {
+        "name": "ncird",
+        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+      },
+      {
+        "name": "ehdi",
+        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
+      },
+      {
+        "name": "eicr",
+        "path_template": "$dataStream/$route/$year/$month/$day/$filename_$uploadId"
       }
     ]
   }

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -12,19 +12,35 @@
     "delivery_targets": [
       {
         "name": "edav",
-        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/upload/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
       },
       {
         "name": "ncird",
-        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
       },
       {
         "name": "ehdi",
-        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/ddnid-ncbddd/DHDD/EHDI/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
       },
       {
         "name": "eicr",
-        "path_template": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        "path_template": {
+          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "TEST": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+        }
       }
     ]
   }

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests_v2.json
@@ -5,7 +5,7 @@
       "data_stream_id": "dextesting",
       "data_stream_route": "testevent1",
       "received_filename": "dex-smoke-test",
-      "sender_id" : "test sender",
+      "sender_id": "test sender",
       "data_producer_id": "test-producer-id",
       "jurisdiction": "test-jurisdiction"
     },
@@ -13,33 +13,37 @@
       {
         "name": "edav",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/edav/{uploadId}",
+          "DEV": "/upload/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/upload/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/upload/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}"
         }
       },
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/ncird/{uploadId}",
+          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/dex-stg/{dataStream}-{route}/{year}/{month}/{day}/{filename}_{uploadId}"
         }
       },
       {
         "name": "ehdi",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/ehdi/{uploadId}",
+          "DEV": "/ddnid-ncbddd/DHDD/EHDI/DEX-DEV/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/ddnid-ncbddd/DHDD/EHDI/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/ddnid-ncbddd/DHDD/EHDI/DEX-STG/{year}/{month}/{day}/{filename}_{uploadId}"
         }
       },
       {
         "name": "eicr",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/eicr/{uploadId}",
+          "DEV": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-DEV/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-STG/{year}/{month}/{day}/{filename}_{uploadId}"
         }
       }
     ]
@@ -62,9 +66,10 @@
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/ncird/{uid}",
+          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }
       }
     ]
@@ -87,9 +92,10 @@
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/ncird/{uid}",
+          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }
       }
     ]
@@ -107,14 +113,15 @@
       "meta_ext_submissionperiod": "smoke submission period",
       "meta_ext_sourceversion": "V2022-12-31",
       "meta_username": "test-username"
-      },
+    },
     "delivery_targets": [
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/dex-test/routine-immunization-zip/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex-dev/routine-immunization-zip/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/routine-immunization-zip/{year}/{month}/{day}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/dex/routine-immunization-zip/{year}/{month}/{day}/{filename}"
         }
       }
     ]
@@ -137,9 +144,10 @@
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }
       }
     ]
@@ -160,9 +168,10 @@
       {
         "name": "eicr",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "DEV": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-DEV/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/ddphss-csels/DDTP/eICR Learning Pilot(eICRLRNG)/DEX-STG/{year}/{month}/{day}/{filename}_{uploadId}"
         }
       }
     ]
@@ -186,9 +195,10 @@
       {
         "name": "ehdi",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/ddnid-ncbddd/DHDD/EHDI/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
+          "DEV": "/ddnid-ncbddd/DHDD/EHDI/DEX-DEV/{year}/{month}/{day}/{filename}_{uploadId}",
           "TEST": "/ddnid-ncbddd/DHDD/EHDI/DEX-TST/{year}/{month}/{day}/{filename}_{uploadId}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/ddnid-ncbddd/DHDD/EHDI/DEX-STG/{year}/{month}/{day}/{hour}/{filename}_{uploadId}"
         }
       }
     ]
@@ -207,9 +217,10 @@
       {
         "name": "edav",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/upload/{dataStream}-{route}/{filename}",
+          "DEV": "/upload/{dataStream}-{route}/{filename}",
           "TEST": "/upload/{dataStream}-{route}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/upload/{dataStream}-{route}/{filename}"
         }
       }
     ]
@@ -233,9 +244,10 @@
       {
         "name": "ncird",
         "path_template": {
-          "DEV": "/{year}/{month}/{day}/{filename}_{uploadId}",
+          "LOCAL": "/{dataStream}-other/{year}/{month}/{day}/{filename}",
+          "DEV": "/{dataStream}-other/{year}/{month}/{day}/{filename}",
           "TEST": "/{dataStream}-other/{year}/{month}/{day}/{filename}",
-          "STAGE": "/{year}/{month}/{day}/{filename}_{uploadId}"
+          "STAGE": "/{dataStream}-other/{year}/{month}/{day}/{filename}"
         }
       }
     ]


### PR DESCRIPTION
Making the end to end kotlin TestNG tests more cloud agnostic and not rely on cloud services to validate results.  The primary change here is rather than going in to Azure to validate results or collect information to validate against, we will use the /info endpoint of the upload api to validate results against and trust those results there.

Changes:

- Add an environment variable to the local.properties files to name the environment being targeted. 
- Remove connecting to the Azure Blob Service from tests and instead utilize the existing uploadClient to get details from the '/info' endpoint given a UID
- change tests to read from a "test case" with manifest details and other validations rather than just a manifest
- Change assertions to validate from the '/info' endpoint results and make assertions more descriptive and informative when they fail.
- Include details to assert against the target path file location and provide details in the test case about the format of this path using tokens that can be replaced with collected data
- Simplify V1 manifest tests to pass (but these will eventually go away as V1 is completely phased out)
- Update Processing Status tests to use a test case rather than a manifest