### PR TITLE
Decouple Delivery Targets From Route Groups

### DIFF
--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"encoding/json"
-	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/metadata"
 	"io"
 	"net/http"
 
@@ -52,8 +51,7 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dataStreamId, dataStreamRoute := metadata.GetDataStreamID(m), metadata.GetDataStreamRoute(m)
-	if _, ok := delivery.GetGroupTarget(dataStreamId, dataStreamRoute, body.Target); !ok {
+	if _, ok := delivery.GetTarget(body.Target); !ok {
 		http.Error(rw, "Invalid target", http.StatusBadRequest)
 		return
 	}

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -32,10 +32,9 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusBadRequest)
 		return
 	}
-
 	sourceName := body.Source
 	if sourceName == "" {
-		sourceName = "upload"
+		sourceName = delivery.UploadSrc
 	}
 	src, ok := delivery.GetSource(sourceName)
 	if !ok {

--- a/upload-server/cmd/cli/route.go
+++ b/upload-server/cmd/cli/route.go
@@ -53,7 +53,7 @@ func (router *Router) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	dataStreamId, dataStreamRoute := metadata.GetDataStreamID(m), metadata.GetDataStreamRoute(m)
-	if _, ok := delivery.GetDestinationTarget(dataStreamId, dataStreamRoute, body.Target); !ok {
+	if _, ok := delivery.GetGroupTarget(dataStreamId, dataStreamRoute, body.Target); !ok {
 		http.Error(rw, "Invalid target", http.StatusBadRequest)
 		return
 	}

--- a/upload-server/cmd/main_test.go
+++ b/upload-server/cmd/main_test.go
@@ -77,6 +77,7 @@ func setUp(name string, c map[string]string) {
 	os.Setenv("SERVER_PORT", fmt.Sprintf("%d", port))
 	os.Setenv("UI_PORT", "")
 	os.Setenv("REDIS_CONNECTION_STRING", "redis://redispw@cache:6379")
+	os.Setenv("DEX_DELIVERY_CONFIG_FILE", "../configs/testing/file.destinations.yml")
 	for key, val := range c {
 		os.Setenv(key, val)
 	}

--- a/upload-server/configs/local/deliver.yml
+++ b/upload-server/configs/local/deliver.yml
@@ -1,106 +1,78 @@
 version: 1.0
 
-az-edav: &az-edav
-  endpoint: $EDAV_ENDPOINT
-  container_name: $EDAV_CHECKPOINT_CONTAINER_NAME
-  tenant_id: $EDAV_TENANT_ID
-  client_id: $EDAV_CLIENT_ID
-  client_secret: $EDAV_CLIENT_SECRET
+targets:
+  - name: edav
+    type: az-blob
+    endpoint: $EDAV_ENDPOINT
+    container_name: $EDAV_CHECKPOINT_CONTAINER_NAME
+    tenant_id: $EDAV_TENANT_ID
+    client_id: $EDAV_CLIENT_ID
+    client_secret: $EDAV_CLIENT_SECRET
+  - name: ehdi
+    type: az-blob
+    endpoint: $EHDI_ENDPOINT
+    container_name: $EHDI_CHECKPOINT_CONTAINER_NAME
+    tenant_id: $EHDI_TENANT_ID
+    client_id: $EHDI_CLIENT_ID
+    client_secret: $EHDI_CLIENT_SECRET
+  - name: eicr
+    type: az-blob
+    endpoint: $EICR_ENDPOINT
+    container_name: $EICR_CHECKPOINT_CONTAINER_NAME
+    tenant_id: $EICR_TENANT_ID
+    client_id: $EICR_CLIENT_ID
+    client_secret: $EICR_CLIENT_SECRET
+  - name: ncird
+    type: az-blob
+    endpoint: $NCIRD_ENDPOINT
+    container_name: $NCIRD_CHECKPOINT_CONTAINER_NAME
+    tenant_id: $NCIRD_TENANT_ID
+    client_id: $NCIRD_CLIENT_ID
+    client_secret: $NCIRD_CLIENT_SECRET
 
-az-ehdi: &az-ehdi
-  endpoint: $EHDI_ENDPOINT
-  container_name: $EHDI_CHECKPOINT_CONTAINER_NAME
-  tenant_id: $EHDI_TENANT_ID
-  client_id: $EHDI_CLIENT_ID
-  client_secret: $EHDI_CLIENT_SECRET
-
-az-eicr: &az-eicr
-  endpoint: $EICR_ENDPOINT
-  container_name: $EICR_CHECKPOINT_CONTAINER_NAME
-  tenant_id: $EICR_TENANT_ID
-  client_id: $EICR_CLIENT_ID
-  client_secret: $EICR_CLIENT_SECRET
-
-az-ncird: &az-ncird
-  endpoint: $NCIRD_ENDPOINT
-  container_name: $NCIRD_CHECKPOINT_CONTAINER_NAME
-  tenant_id: $NCIRD_TENANT_ID
-  client_id: $NCIRD_CLIENT_ID
-  client_secret: $NCIRD_CLIENT_SECRET
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: az-blob
-        <<: *az-edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: az-blob
         path_template: $EHDI_PATH_TEMPLATE
-        <<: *az-ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: az-blob
         path_template: $EICR_PATH_TEMPLATE
-        <<: *az-eicr
   - data_stream_id: covid-all-monthly-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
         path_template: generic-immunization-other/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}
-        <<: *az-ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: az-blob
         path_template: routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}
-        <<: *az-ncird
   - data_stream_id: rsv-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
       - name: eicr
-        type: az-blob
         path_template: $EICR_PATH_TEMPLATE
-        <<: *az-eicr
       - name: ehdi
-        type: az-blob
         path_template: $EHDI_PATH_TEMPLATE
-        <<: *az-ehdi
       - name: edav
-        type: az-blob
-        <<: *az-edav

--- a/upload-server/configs/local/deliver.yml
+++ b/upload-server/configs/local/deliver.yml
@@ -1,28 +1,32 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: az-blob
     endpoint: $EDAV_ENDPOINT
     container_name: $EDAV_CHECKPOINT_CONTAINER_NAME
     tenant_id: $EDAV_TENANT_ID
     client_id: $EDAV_CLIENT_ID
     client_secret: $EDAV_CLIENT_SECRET
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: az-blob
     endpoint: $EHDI_ENDPOINT
     container_name: $EHDI_CHECKPOINT_CONTAINER_NAME
     tenant_id: $EHDI_TENANT_ID
     client_id: $EHDI_CLIENT_ID
     client_secret: $EHDI_CLIENT_SECRET
-  - name: eicr
+  eicr:
+    name: eicr
     type: az-blob
     endpoint: $EICR_ENDPOINT
     container_name: $EICR_CHECKPOINT_CONTAINER_NAME
     tenant_id: $EICR_TENANT_ID
     client_id: $EICR_CLIENT_ID
     client_secret: $EICR_CLIENT_SECRET
-  - name: ncird
+  ncird:
+    name: ncird
     type: az-blob
     endpoint: $NCIRD_ENDPOINT
     container_name: $NCIRD_CHECKPOINT_CONTAINER_NAME

--- a/upload-server/configs/testing/azurite_destinations.yml
+++ b/upload-server/configs/testing/azurite_destinations.yml
@@ -1,25 +1,29 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"
     storage_key: $AZURITE_KEY
     container_name: edav
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"
     storage_key: $AZURITE_KEY
     container_name: ehdi
-  - name: eicr
+  eicr:
+    name: eicr
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"
     storage_key: $AZURITE_KEY
     container_name: eicr
-  - name: ncird
+  ncird:
+    name: ncird
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"

--- a/upload-server/configs/testing/azurite_destinations.yml
+++ b/upload-server/configs/testing/azurite_destinations.yml
@@ -1,98 +1,69 @@
 version: 1.0
 
-az-edav: &az-edav
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: edav
-
-az-ehdi: &az-ehdi
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: ehdi
-
-az-eicr: &az-eicr
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: eicr
-
-az-ncird: &az-ncird
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: ncird
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+targets:
+  - name: edav
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: edav
+  - name: ehdi
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: ehdi
+  - name: eicr
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: eicr
+  - name: ncird
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: ncird
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: az-blob
-        <<: *az-edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: az-blob
         path_template: $EHDI_PATH_TEMPLATE
-        <<: *az-ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: az-blob
         path_template: $EICR_PATH_TEMPLATE
-        <<: *az-eicr
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
       - name: eicr
-        type: az-blob
-        <<: *az-eicr
       - name: edav
-        type: az-blob
-        <<: *az-edav
       - name: ehdi
-        type: az-blob
-        <<: *az-ehdi

--- a/upload-server/configs/testing/file_destinations.yml
+++ b/upload-server/configs/testing/file_destinations.yml
@@ -1,16 +1,20 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: file
     path: ./uploads/edav
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: file
     path: ./uploads/ehdi
-  - name: eicr
+  eicr:
+    name: eicr
     type: file
     path: ./uploads/eicr
-  - name: ncird
+  ncird:
+    name: ncird
     type: file
     path: ./uploads/ncird
 

--- a/upload-server/configs/testing/file_destinations.yml
+++ b/upload-server/configs/testing/file_destinations.yml
@@ -1,96 +1,56 @@
 version: 1.0
 
-az-edav: &az-edav
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: edav
+targets:
+  - name: edav
+    type: file
+    path: ./uploads/edav
+  - name: ehdi
+    type: file
+    path: ./uploads/ehdi
+  - name: eicr
+    type: file
+    path: ./uploads/eicr
+  - name: ncird
+    type: file
+    path: ./uploads/ncird
 
-az-ehdi: &az-ehdi
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: ehdi
-
-az-eicr: &az-eicr
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: eicr
-
-az-ncird: &az-ncird
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: ncird
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: file
-        path: ./uploads/edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: file
-        path: ./uploads/ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: file
-        path: ./uploads/eicr
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: file
-        path: ./uploads/ncird
       - name: eicr
-        type: file
-        path: ./uploads/eicr
       - name: edav
-        type: file
-        path: ./uploads/edav
       - name: ehdi
-        type: file
-        path: ./uploads/ehdi

--- a/upload-server/configs/testing/mix_destinations.yml
+++ b/upload-server/configs/testing/mix_destinations.yml
@@ -1,27 +1,31 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: s3
     bucket_name: edav
     access_key_id: minioadmin
     secret_access_key: minioadmin
     endpoint: "http://minio:8000"
     region: us-east-1
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: s3
     bucket_name: ehdi
     access_key_id: minioadmin
     secret_access_key: minioadmin
     endpoint: "http://minio:8000"
     region: us-east-1
-  - name: eicr
+  eicr:
+    name: eicr
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"
     storage_key: $AZURITE_KEY
     container_name: eicr
-  - name: ncird
+  ncird:
+    name: ncird
     type: az-blob
     endpoint: "http://azurite:10000/devstoreaccount1"
     storage_account: "devstoreaccount1"

--- a/upload-server/configs/testing/mix_destinations.yml
+++ b/upload-server/configs/testing/mix_destinations.yml
@@ -1,100 +1,71 @@
 version: 1.0
 
-s3-edav: &s3-edav
-  bucket_name: edav
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
-
-s3-ehdi: &s3-ehdi
-  bucket_name: ehdi
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
-
-az-eicr: &az-eicr
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: eicr
-
-az-ncird: &az-ncird
-  endpoint: "http://azurite:10000/devstoreaccount1"
-  storage_account: "devstoreaccount1"
-  storage_key: $AZURITE_KEY
-  container_name: ncird
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+targets:
+  - name: edav
+    type: s3
+    bucket_name: edav
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
+  - name: ehdi
+    type: s3
+    bucket_name: ehdi
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
+  - name: eicr
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: eicr
+  - name: ncird
+    type: az-blob
+    endpoint: "http://azurite:10000/devstoreaccount1"
+    storage_account: "devstoreaccount1"
+    storage_key: $AZURITE_KEY
+    container_name: ncird
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: s3
-        <<: *s3-edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: s3
         path_template: $EHDI_PATH_TEMPLATE
-        <<: *s3-ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: az-blob
         path_template: $EICR_PATH_TEMPLATE
-        <<: *az-eicr
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: az-blob
-        <<: *az-ncird
       - name: eicr
-        type: az-blob
-        <<: *az-eicr
       - name: edav
-        type: s3
-        <<: *s3-edav
       - name: ehdi
-        type: s3
-        <<: *s3-ehdi

--- a/upload-server/configs/testing/s3_destinations.yml
+++ b/upload-server/configs/testing/s3_destinations.yml
@@ -1,102 +1,76 @@
 version: 1.0
 
-s3-edav: &s3-edav
-  bucket_name: edav
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
+targets:
+  - name: edav
+    type: s3
+    bucket_name: edav
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
 
-s3-ehdi: &s3-ehdi
-  bucket_name: ehdi
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
+  - name: ehdi
+    type: s3
+    bucket_name: ehdi
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
 
-s3-eicr: &s3-eicr
-  bucket_name: eicr
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
+  - name: eicr
+    type: s3
+    bucket_name: eicr
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
 
-s3-ncird: &s3-ncird
-  bucket_name: ncird
-  access_key_id: minioadmin
-  secret_access_key: minioadmin
-  endpoint: "http://minio:8000"
-  region: us-east-1
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+  - name: ncird
+    type: s3
+    bucket_name: ncird
+    access_key_id: minioadmin
+    secret_access_key: minioadmin
+    endpoint: "http://minio:8000"
+    region: us-east-1
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: s3
-        <<: *s3-edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: s3
         path_template: $EHDI_PATH_TEMPLATE
-        <<: *s3-ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: s3
         path_template: $EICR_PATH_TEMPLATE
-        <<: *s3-eicr
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: s3
-        <<: *s3-ncird
       - name: eicr
-        type: s3
-        <<: *s3-eicr
       - name: edav
-        type: s3
-        <<: *s3-edav
       - name: ehdi
-        type: s3
-        <<: *s3-ehdi

--- a/upload-server/configs/testing/s3_destinations.yml
+++ b/upload-server/configs/testing/s3_destinations.yml
@@ -1,31 +1,32 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: s3
     bucket_name: edav
     access_key_id: minioadmin
     secret_access_key: minioadmin
     endpoint: "http://minio:8000"
     region: us-east-1
-
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: s3
     bucket_name: ehdi
     access_key_id: minioadmin
     secret_access_key: minioadmin
     endpoint: "http://minio:8000"
     region: us-east-1
-
-  - name: eicr
+  eicr:
+    name: eicr
     type: s3
     bucket_name: eicr
     access_key_id: minioadmin
     secret_access_key: minioadmin
     endpoint: "http://minio:8000"
     region: us-east-1
-
-  - name: ncird
+  ncird:
+    name: ncird
     type: s3
     bucket_name: ncird
     access_key_id: minioadmin

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -151,6 +151,7 @@ func unmarshalDeliveryConfig(confBody string) (*Config, error) {
 
 // Eventually, this can take a more generic list of deliverer configuration object
 func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.AppConfig) (err error) {
+	targets = make(map[string]Destination)
 	groups = make(map[string]Group)
 	var src Source
 
@@ -170,6 +171,7 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 	}
 
 	for _, t := range cfg.Targets {
+		targets[t.Name] = t.Destination
 		if err := health.Register(t.Destination); err != nil {
 			slog.Error("failed to register destination", "destination", t)
 		}

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -30,36 +30,8 @@ var UploadSrc = "upload"
 
 var ErrSrcFileNotExist = fmt.Errorf("source file does not exist")
 
-// TODO
-// populate groups
-// get health checks from targets
-// try and delete destinations
 var groups map[string]Group
 var targets map[string]Destination
-
-//var destinations = map[string]map[string]Destination{}
-
-//func RegisterDestination(name string, targetName string, d Destination) {
-//	if _, ok := destinations[name]; ok {
-//		destinations[name][targetName] = d
-//	} else {
-//		destinations[name] = map[string]Destination{targetName: d}
-//	}
-//}
-
-//func GetGroupTargetNames(group Group) []string {
-//	targets, ok := destinations[group.Key()]
-//	if !ok {
-//		return []string{}
-//	}
-//	targetNames := make([]string, len(targets))
-//	i := 0
-//	for t := range targets {
-//		targetNames[i] = t
-//		i++
-//	}
-//	return targetNames
-//}
 
 func GetTarget(target string) (Destination, bool) {
 	d, ok := targets[target]
@@ -225,14 +197,6 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 		if g.DeliveryTargets == nil {
 			slog.Warn(fmt.Sprintf("no targets configured for group %s", g.Key()))
 		}
-		//for _, t := range g.DeliveryTargets {
-		//	d, ok := targets[t.Name]
-		//	if !ok {
-		//		return fmt.Errorf("target %s not found", t.Name)
-		//	}
-		//
-		//	RegisterDestination(g.Key(), t.Name, d)
-		//}
 	}
 
 	if appConfig.AzureConnection != nil {

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -26,6 +26,8 @@ import (
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/storeaz"
 )
 
+var UploadSrc = "upload"
+
 var ErrSrcFileNotExist = fmt.Errorf("source file does not exist")
 
 // TODO
@@ -193,6 +195,8 @@ func unmarshalDeliveryConfig(confBody string) (*Config, error) {
 
 // Eventually, this can take a more generic list of deliverer configuration object
 func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.AppConfig) (err error) {
+	groups = make(map[string]Group)
+	targets = make(map[string]Destination)
 	var src Source
 	var dests []Destination
 	fromPathStr := filepath.Join(appConfig.LocalFolderUploadsTus, appConfig.TusUploadPrefix)
@@ -214,6 +218,7 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 		targets[t.Name] = t.Destination
 		dests = append(dests, t.Destination)
 	}
+	slog.Info("targets", "targets", targets)
 
 	for _, g := range cfg.Groups {
 		groups[g.Key()] = g
@@ -252,7 +257,7 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 			Prefix:     appConfig.TusUploadPrefix,
 		}
 	}
-	RegisterSource("upload", src)
+	RegisterSource(UploadSrc, src)
 
 	if err := health.Register(getDeliveryHealthChecks([]Source{src}, dests)...); err != nil {
 		slog.Error("failed to register some health checks", "error", err)

--- a/upload-server/internal/delivery/s3.go
+++ b/upload-server/internal/delivery/s3.go
@@ -101,7 +101,7 @@ type S3Destination struct {
 	Region          string `yaml:"region"`
 }
 
-func (sd *S3Destination) Retrieve(ctx context.Context) (aws.Credentials, error) {
+func (sd *S3Destination) Retrieve(_ context.Context) (aws.Credentials, error) {
 	return aws.Credentials{
 		AccessKeyID:     sd.AccessKeyID,
 		SecretAccessKey: sd.SecretAccessKey,

--- a/upload-server/internal/postprocessing/merge.go
+++ b/upload-server/internal/postprocessing/merge.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/delivery"
 	evt "github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
-	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/metadata"
 	"github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
 )

--- a/upload-server/internal/postprocessing/merge.go
+++ b/upload-server/internal/postprocessing/merge.go
@@ -23,9 +23,6 @@ func RouteAndDeliverHook() func(handler.HookEvent, hooks.HookResponse) (hooks.Ho
 			return resp, fmt.Errorf("no routing group found for metadata %+v", meta)
 		}
 
-		//dataStreamId, dataStreamRoute := metadata.GetDataStreamID(meta), metadata.GetDataStreamRoute(meta)
-		//targets := delivery.GetGroupTargetNames(dataStreamId, dataStreamRoute)
-
 		for _, target := range routeGroup.TargetNames() {
 			e := evt.NewFileReadyEvent(id, meta, target)
 			err := evt.FileReadyPublisher.Publish(ctx, e)

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -3,7 +3,6 @@ package postprocessing
 import (
 	"context"
 	"fmt"
-	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/metadata"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -59,12 +58,7 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 		})
 		return err
 	}
-	dataStreamId := metadata.GetDataStreamID(e.Metadata)
-	dataStreamRoute := metadata.GetDataStreamRoute(e.Metadata)
-	d, ok := delivery.GetGroupTarget(delivery.Group{
-		DataStreamId:    dataStreamId,
-		DataStreamRoute: dataStreamRoute,
-	}, e.DestinationTarget)
+	d, ok := delivery.GetTarget(e.DestinationTarget)
 	if !ok {
 		err := fmt.Errorf("failed to get destination for file delivery %+v", e)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -61,7 +61,7 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	}
 	dataStreamId := metadata.GetDataStreamID(e.Metadata)
 	dataStreamRoute := metadata.GetDataStreamRoute(e.Metadata)
-	d, ok := delivery.GetDestinationTarget(dataStreamId, dataStreamRoute, e.DestinationTarget)
+	d, ok := delivery.GetGroupTarget(dataStreamId, dataStreamRoute, e.DestinationTarget)
 	if !ok {
 		err := fmt.Errorf("failed to get destination for file delivery %+v", e)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -61,7 +61,10 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	}
 	dataStreamId := metadata.GetDataStreamID(e.Metadata)
 	dataStreamRoute := metadata.GetDataStreamRoute(e.Metadata)
-	d, ok := delivery.GetGroupTarget(dataStreamId, dataStreamRoute, e.DestinationTarget)
+	d, ok := delivery.GetGroupTarget(delivery.Group{
+		DataStreamId:    dataStreamId,
+		DataStreamRoute: dataStreamRoute,
+	}, e.DestinationTarget)
 	if !ok {
 		err := fmt.Errorf("failed to get destination for file delivery %+v", e)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/delivery"
 	"io"
 	"log"
 	"net/http"
@@ -44,7 +45,6 @@ var (
 )
 
 const TestFolderUploadsTus = "uploads"
-const TestDEXFolder = "uploads/dex"
 const TestEDAVFolder = "uploads/edav"
 const TestEhdiFolder = "uploads/ehdi"
 const TestEicrFolder = "uploads/eicr"
@@ -206,12 +206,12 @@ func TestTus(t *testing.T) {
 }
 
 func TestRouteEndpoint(t *testing.T) {
-	c := Cases["good"]
+	c := Cases["v2 good"]
 	tuid, err := RunTusTestCase(ts.URL, "test.txt", c)
 	time.Sleep(2 * time.Second) // Hard delay to wait for all non-blocking hooks to finish.
 
 	if err != nil {
-		t.Error("edav", err)
+		t.Error("error", err)
 	} else {
 		if tuid == "" {
 			t.Error("could not create tuid")
@@ -606,9 +606,11 @@ func TestMain(m *testing.M) {
 	testContext = context.Background()
 	var testWaitGroup sync.WaitGroup
 	defer testWaitGroup.Wait()
+
+	err := delivery.RegisterAllSourcesAndDestinations(testContext, appConfig)
 	event.InitFileReadyChannel()
 	testWaitGroup.Add(1)
-	err := cli.InitReporters(testContext, appConfig)
+	err = cli.InitReporters(testContext, appConfig)
 	defer reports.CloseAll()
 	err = event.InitFileReadyPublisher(testContext, appConfig)
 	defer event.FileReadyPublisher.Close()
@@ -673,56 +675,6 @@ func readReportFiles(tuid string, stages []string) (ReportFileSummary, error) {
 			}
 
 			appendReport(summary, r)
-		}
-	}
-
-	return summary, nil
-}
-
-func readReportFile(tuid string) (ReportFileSummary, error) {
-	summary := ReportFileSummary{
-		Tuid:      tuid,
-		Summaries: map[string]ReportSummary{},
-	}
-
-	// Steps for categorized report files
-	// 1. get list of report types we want to track
-	// 2. for each type, read file for that type and upload id
-	// 3. for each line, unmarshal and count
-
-	trackedStages := []string{
-		reports.StageMetadataVerify,
-		reports.StageMetadataTransform,
-		reports.StageUploadCompleted,
-		reports.StageUploadStarted,
-		reports.StageUploadStatus,
-		reports.StageFileCopy,
-	}
-
-	f, err := os.Open(TestReportsFolder + "/" + tuid)
-	if err != nil {
-		return summary, fmt.Errorf("failed to open report file for %s; inner error %w", tuid, err)
-	}
-
-	b, err := io.ReadAll(f)
-	if err != nil {
-		return summary, fmt.Errorf("failed to read report file %s; inner error %w", f.Name(), err)
-	}
-
-	rScanner := bufio.NewScanner(strings.NewReader(string(b)))
-	for rScanner.Scan() {
-		rLine := rScanner.Text()
-		rLineBytes := []byte(rLine)
-
-		r, err := unmarshalReport(rLineBytes)
-		if err != nil {
-			return summary, err
-		}
-
-		for _, s := range trackedStages {
-			if strings.Contains(rLine, s) {
-				appendReport(summary, r)
-			}
 		}
 	}
 

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -1,16 +1,20 @@
 version: 1.0
 
 targets:
-  - name: edav
+  edav:
+    name: edav
     type: file
     path: ./uploads/edav
-  - name: ehdi
+  ehdi:
+    name: ehdi
     type: file
     path: ./uploads/ehdi
-  - name: eicr
+  eicr:
+    name: eicr
     type: file
     path: ./uploads/eicr
-  - name: ncird
+  ncird:
+    name: ncird
     type: file
     path: ./uploads/ncird
 

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -1,86 +1,56 @@
 version: 1.0
 
-az-edav: &az-edav
-  path: "./uploads/edav"
+targets:
+  - name: edav
+    type: file
+    path: ./uploads/edav
+  - name: ehdi
+    type: file
+    path: ./uploads/ehdi
+  - name: eicr
+    type: file
+    path: ./uploads/eicr
+  - name: ncird
+    type: file
+    path: ./uploads/ncird
 
-az-ehdi: &az-ehdi
-  path: "./uploads/ehdi"
-
-az-eicr: &az-eicr
-  path: "./uploads/eicr"
-
-az-ncird: &az-ncird
-  path: "./uploads/ncird"
-
-# if needed, properties of an anchor can be overridden
-# in a delivery target
-#
-# path_template can be defined at data_stream level
-# where it is valid for all targets unless
-# a target defines its own path_template property
-programs:
+routing_groups:
   - data_stream_id: pulsenet
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        type: file
-        <<: *az-edav
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
       - name: ehdi
-        type: file
-        path_template: $EHDI_PATH_TEMPLATE
-        <<: *az-ehdi
   - data_stream_id: eicr
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
-        type: file
-        path_template: $EICR_PATH_TEMPLATE
-        <<: *az-eicr
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
   - data_stream_id: generic-immunization
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
   - data_stream_id: influenza-vaccination
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
   - data_stream_id: routine-immunization
     data_stream_route: other
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
   - data_stream_id: dextesting
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        type: file
-        <<: *az-ncird
       - name: eicr
-        type: file
-        <<: *az-eicr
       - name: edav
-        type: file
-        <<: *az-edav
       - name: ehdi
-        type: file
-        <<: *az-ehdi


### PR DESCRIPTION
This is an iteration on the deliver configuration schema.  The goal is to decouple delivery targets from routing groups.  This will improve robustness by preventing possible misconfiguration of creating multiple delivery targets with the same name.  With this, we want to make sure the server fails to start if the deliver yml is misconfiguration in this way.