### PR TITLE
set delivery name on builder init

### DIFF
--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -35,7 +35,14 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 		"1.0.0",
 		reports.StageFileCopy,
 		e.UploadId,
-		reports.DispositionTypeAdd).SetStartTime(time.Now().UTC())
+		reports.DispositionTypeAdd).SetStartTime(time.Now().UTC()).SetContent(reports.FileCopyContent{
+		ReportContent: reports.ReportContent{
+			ContentSchemaVersion: "1.0.0",
+			ContentSchemaName:    reports.StageFileCopy,
+		},
+		FileSourceBlobUrl: e.SrcUrl,
+		DestinationName:   e.DestinationTarget,
+	})
 
 	defer func() {
 		rb.SetEndTime(time.Now().UTC())


### PR DESCRIPTION
This patch fixes an issue where delivery info for a blob copy report won't get set if there is a delivery failure.  The fix is to simply set the info when the builder for the report is instantiated.