### PR TITLE
separate config vars for UI server host assignment

### DIFF
--- a/upload-server/internal/appconfig/appconfig.go
+++ b/upload-server/internal/appconfig/appconfig.go
@@ -58,8 +58,10 @@ type AppConfig struct {
 	TusUploadPrefix string `env:"TUS_UPLOAD_PREFIX, default=tus-prefix"`
 
 	// UI
-	UIPort    string `env:"UI_PORT, default=:8081"`
-	CsrfToken string `env:"CSRF_TOKEN, default=1qQBJumxRABFBLvaz5PSXBcXLE84viE42x4Aev359DvLSvzjbXSme3whhFkESatW"`
+	UIPort           string `env:"UI_PORT, default=:8081"`
+	UIServerProtocol string `env:"UI_SERVER_PROTOCOL, default=http"`
+	UIServerHost     string `env:"UI_SERVER_HOSTNAME, default=localhost:8080"`
+	CsrfToken        string `env:"CSRF_TOKEN, default=1qQBJumxRABFBLvaz5PSXBcXLE84viE42x4Aev359DvLSvzjbXSme3whhFkESatW"`
 	// WARNING: the default CsrfToken value is for local development use only, it needs to be replaced by a secret 32 byte string before being used in production
 
 	// TUS Upload file lock
@@ -209,7 +211,7 @@ func ParseConfig(ctx context.Context) (AppConfig, error) {
 		}
 	}
 
-	ac.ServerUrl = fmt.Sprintf("%s://%s:%s", ac.ServerProtocol, ac.ServerHostname, ac.ServerPort)
+	ac.ServerUrl = fmt.Sprintf("%s://%s", ac.UIServerProtocol, ac.UIServerHost)
 	ac.ServerFileEndpointUrl = ac.ServerUrl + ac.TusdHandlerBasePath
 	ac.ServerInfoEndpointUrl = ac.ServerUrl + ac.TusdHandlerInfoPath
 


### PR DESCRIPTION
This patch is to allow the browser to send requests to the server in a deployed environment.  Currently, the port number that the upload service listens on is also used by the browser to send upload requests to.  This won't work for a deployed environment, when the browser needs to send requests to port 443.  We can tell the browser to send requests to 443 by setting the SERVER_PORT config var, but this causes the service to fail to start because it will listen on 443, which it may not have access to do so, and another service is likely already using this port on the box it is deployed to.

This patch alleviates this conflict by separating the host (and port) that the browser uses from the one that the server listens on.