### PR TITLE
PHDO-87: Use dex_ingest_datetime for file delivery

### DIFF
--- a/upload-server/configs/local/deliver.yml
+++ b/upload-server/configs/local/deliver.yml
@@ -39,6 +39,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/configs/local/deliver.yml
+++ b/upload-server/configs/local/deliver.yml
@@ -39,7 +39,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/configs/local/deliver.yml
+++ b/upload-server/configs/local/deliver.yml
@@ -39,7 +39,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
+        path_template: "{{.DataStreamID}}-{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -76,8 +76,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        path_template: "phdo-testing/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        path_template: $EICR_PATH_TEMPLATE
+        path_template: "phdo-testing/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        path_template: $EHDI_PATH_TEMPLATE
+        path_template: "phdo-testing/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        path_template: "phdo-testing/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/azurite_destinations.yml
+++ b/upload-server/configs/testing/azurite_destinations.yml
@@ -34,6 +34,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/configs/testing/azurite_destinations.yml
+++ b/upload-server/configs/testing/azurite_destinations.yml
@@ -34,7 +34,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -69,6 +69,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/azurite_destinations.yml
+++ b/upload-server/configs/testing/azurite_destinations.yml
@@ -69,10 +69,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/file_destinations.yml
+++ b/upload-server/configs/testing/file_destinations.yml
@@ -56,10 +56,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/file_destinations.yml
+++ b/upload-server/configs/testing/file_destinations.yml
@@ -23,6 +23,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/configs/testing/file_destinations.yml
+++ b/upload-server/configs/testing/file_destinations.yml
@@ -23,7 +23,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -56,6 +56,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/mix_destinations.yml
+++ b/upload-server/configs/testing/mix_destinations.yml
@@ -71,10 +71,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/mix_destinations.yml
+++ b/upload-server/configs/testing/mix_destinations.yml
@@ -36,6 +36,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/configs/testing/mix_destinations.yml
+++ b/upload-server/configs/testing/mix_destinations.yml
@@ -36,7 +36,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -71,6 +71,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/s3_destinations.yml
+++ b/upload-server/configs/testing/s3_destinations.yml
@@ -73,10 +73,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/s3_destinations.yml
+++ b/upload-server/configs/testing/s3_destinations.yml
@@ -38,7 +38,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -73,6 +73,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/configs/testing/s3_destinations.yml
+++ b/upload-server/configs/testing/s3_destinations.yml
@@ -38,6 +38,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/internal/delivery/azure.go
+++ b/upload-server/internal/delivery/azure.go
@@ -98,16 +98,11 @@ func (ad *AzureDestination) Client() (*container.Client, error) {
 }
 
 func (ad *AzureDestination) Upload(ctx context.Context, path string, r io.Reader, m map[string]string) (string, error) {
-	blobName, err := getDeliveredFilename(ctx, path, ad.PathTemplate, m)
-	if err != nil {
-		return blobName, err
-	}
-
 	c, err := ad.Client()
 	if err != nil {
-		return blobName, err
+		return path, err
 	}
-	client := c.NewBlockBlobClient(blobName)
+	client := c.NewBlockBlobClient(path)
 
 	_, err = client.UploadStream(ctx, r, &azblob.UploadStreamOptions{
 		Metadata: storeaz.PointerizeMetadata(m),

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -220,14 +220,14 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 }
 
 // target may end up being a type
-func Deliver(ctx context.Context, path string, s Source, d Destination) (string, error) {
+func Deliver(ctx context.Context, id string, path string, s Source, d Destination) (string, error) {
 
-	manifest, err := s.GetMetadata(ctx, path)
+	manifest, err := s.GetMetadata(ctx, id)
 	if err != nil {
 		return "", err
 	}
 
-	r, err := s.Reader(ctx, path)
+	r, err := s.Reader(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +239,7 @@ func Deliver(ctx context.Context, path string, s Source, d Destination) (string,
 
 var ErrBadIngestTimestamp = errors.New("bad ingest timestamp")
 
-func getDeliveredFilename(ctx context.Context, tuid string, pathTemplate string, manifest map[string]string) (string, error) {
+func GetDeliveredFilename(ctx context.Context, tuid string, pathTemplate string, manifest map[string]string) (string, error) {
 	if pathTemplate == "" {
 		pathTemplate = "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}"
 	}

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/tus/tusd/v2/pkg/handler"
 	"io"
 	"log/slog"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/tus/tusd/v2/pkg/handler"
 
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
 	"gopkg.in/yaml.v3"
@@ -242,7 +243,14 @@ func getDeliveredFilename(ctx context.Context, tuid string, pathTemplate string,
 	// TODO eventually everything will come from path template
 	if pathTemplate != "" {
 		// Use path template to form the full name.
-		t := time.Now().UTC()
+		rawTime, ok := manifest["dex_ingest_datetime"]
+		if !ok {
+			return "", errors.New("bad ingest timestamp")
+		}
+		t, err := time.Parse(time.RFC3339Nano, rawTime)
+		if err != nil {
+			return "", err
+		}
 		m := fmt.Sprintf("%02d", t.Month())
 		d := fmt.Sprintf("%02d", t.Day())
 		h := fmt.Sprintf("%02d", t.Hour())

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
 	"gopkg.in/yaml.v3"
 
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/stores3"
 	metadataPkg "github.com/cdcgov/data-exchange-upload/upload-server/pkg/metadata"
 
@@ -70,12 +69,16 @@ type Destination interface {
 }
 
 type PathInfo struct {
-	Year     string
-	Month    string
-	Day      string
-	Hour     string
-	UploadId string
-	Filename string
+	Year            string
+	Month           string
+	Day             string
+	Hour            string
+	UploadId        string
+	Filename        string
+	Suffix          string
+	Prefix          string
+	DataStreamID    string
+	DataStreamRoute string
 }
 
 type Config struct {
@@ -237,64 +240,50 @@ func Deliver(ctx context.Context, path string, s Source, d Destination) (string,
 var ErrBadIngestTimestamp = errors.New("bad ingest timestamp")
 
 func getDeliveredFilename(ctx context.Context, tuid string, pathTemplate string, manifest map[string]string) (string, error) {
+	if pathTemplate == "" {
+		pathTemplate = "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}"
+	}
 	// First, build the filename from the manifest and config.  This will be the default.
 	filename := metadataPkg.GetFilename(manifest)
 	extension := filepath.Ext(filename)
 	filenameWithoutExtension := strings.TrimSuffix(filename, extension)
 
-	// TODO eventually everything will come from path template
-	if pathTemplate != "" {
-		// Use path template to form the full name.
-		rawTime, ok := manifest["dex_ingest_datetime"]
-		if !ok {
-			return "", ErrBadIngestTimestamp
-		}
-		t, err := time.Parse(time.RFC3339Nano, rawTime)
-		if err != nil {
-			return "", errors.Join(err, ErrBadIngestTimestamp)
-		}
-		m := fmt.Sprintf("%02d", t.Month())
-		d := fmt.Sprintf("%02d", t.Day())
-		h := fmt.Sprintf("%02d", t.Hour())
-		pathInfo := &PathInfo{
-			Year:     strconv.Itoa(t.Year()),
-			Month:    m,
-			Day:      d,
-			Hour:     h,
-			Filename: filenameWithoutExtension,
-			UploadId: tuid,
-		}
-		tmpl, err := template.New("path").Parse(pathTemplate)
-		if err != nil {
-			return "", err
-		}
-		b := new(bytes.Buffer)
-		err = tmpl.Execute(b, pathInfo)
-		if err != nil {
-			return "", err
-		}
-
-		if extension != "" {
-			return b.String() + extension, nil
-		}
-
-		return b.String(), nil
+	// Use path template to form the full name.
+	rawTime, ok := manifest["dex_ingest_datetime"]
+	if !ok {
+		return "", ErrBadIngestTimestamp
 	}
-
-	// Otherwise, use the suffix and folder structure values
-	suffix, err := metadata.GetFilenameSuffix(ctx, manifest, tuid)
+	t, err := time.Parse(time.RFC3339Nano, rawTime)
+	if err != nil {
+		return "", errors.Join(err, ErrBadIngestTimestamp)
+	}
+	m := fmt.Sprintf("%02d", t.Month())
+	d := fmt.Sprintf("%02d", t.Day())
+	h := fmt.Sprintf("%02d", t.Hour())
+	pathInfo := &PathInfo{
+		Year:            strconv.Itoa(t.Year()),
+		Month:           m,
+		Day:             d,
+		Hour:            h,
+		Filename:        filenameWithoutExtension,
+		UploadId:        tuid,
+		DataStreamID:    metadataPkg.GetDataStreamID(manifest),
+		DataStreamRoute: metadataPkg.GetDataStreamID(manifest),
+	}
+	tmpl, err := template.New("path").Parse(pathTemplate)
 	if err != nil {
 		return "", err
 	}
-	blobName := filenameWithoutExtension + suffix + extension
-
-	// Next, need to set the filename prefix based on config and target.
-	prefix := ""
-
-	prefix, err = metadata.GetFilenamePrefix(ctx, manifest)
+	b := new(bytes.Buffer)
+	err = tmpl.Execute(b, pathInfo)
 	if err != nil {
 		return "", err
 	}
 
-	return prefix + "/" + blobName, nil
+	if extension != "" {
+		return b.String() + extension, nil
+	}
+
+	return b.String(), nil
+
 }

--- a/upload-server/internal/delivery/deliver.go
+++ b/upload-server/internal/delivery/deliver.go
@@ -234,6 +234,8 @@ func Deliver(ctx context.Context, path string, s Source, d Destination) (string,
 	return d.Upload(ctx, path, r, manifest)
 }
 
+var ErrBadIngestTimestamp = errors.New("bad ingest timestamp")
+
 func getDeliveredFilename(ctx context.Context, tuid string, pathTemplate string, manifest map[string]string) (string, error) {
 	// First, build the filename from the manifest and config.  This will be the default.
 	filename := metadataPkg.GetFilename(manifest)
@@ -245,11 +247,11 @@ func getDeliveredFilename(ctx context.Context, tuid string, pathTemplate string,
 		// Use path template to form the full name.
 		rawTime, ok := manifest["dex_ingest_datetime"]
 		if !ok {
-			return "", errors.New("bad ingest timestamp")
+			return "", ErrBadIngestTimestamp
 		}
 		t, err := time.Parse(time.RFC3339Nano, rawTime)
 		if err != nil {
-			return "", err
+			return "", errors.Join(err, ErrBadIngestTimestamp)
 		}
 		m := fmt.Sprintf("%02d", t.Month())
 		d := fmt.Sprintf("%02d", t.Day())

--- a/upload-server/internal/delivery/delivery_test.go
+++ b/upload-server/internal/delivery/delivery_test.go
@@ -1,0 +1,44 @@
+package delivery
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestGetDeliveredFilename(t *testing.T) {
+	type testCase struct {
+		ctx          context.Context
+		tuid         string
+		pathTemplate string
+		manifest     map[string]string
+		err          error
+		result       string
+	}
+	ctx := context.Background()
+	testTime := time.Date(2020, time.April, 11, 15, 12, 30, 50, time.UTC)
+
+	testCases := []testCase{
+		{
+			ctx,
+			"bogus-id",
+			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
+			map[string]string{
+				"dex_ingest_datetime": testTime.Format(time.RFC3339Nano),
+				"filename":            "test.txt",
+			},
+			nil,
+			"routine-immunization-zip/2020/04/11/test.txt",
+		},
+	}
+
+	for i, c := range testCases {
+		res, err := getDeliveredFilename(c.ctx, c.tuid, c.pathTemplate, c.manifest)
+		if res != c.result {
+			t.Errorf("missmatched results for test case %d: got %s expected %s", i, res, c.result)
+		}
+		if err != c.err {
+			t.Errorf("missmatched errors for test case %d: got %+v expected %+v", i, err, c.err)
+		}
+	}
+}

--- a/upload-server/internal/delivery/delivery_test.go
+++ b/upload-server/internal/delivery/delivery_test.go
@@ -25,6 +25,9 @@ func TestGetDeliveredFilename(t *testing.T) {
 			"bogus-id",
 			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
 			map[string]string{
+				"version":             "2.0",
+				"data_stream_id":      "dextesting",
+				"data_stream_route":   "testevent1",
 				"dex_ingest_datetime": testTime.Format(time.RFC3339Nano),
 				"filename":            "test.txt",
 			},
@@ -36,6 +39,9 @@ func TestGetDeliveredFilename(t *testing.T) {
 			"bogus-id",
 			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
 			map[string]string{
+				"version":             "2.0",
+				"data_stream_id":      "dextesting",
+				"data_stream_route":   "testevent1",
 				"dex_ingest_datetime": "bogus time",
 				"filename":            "test.txt",
 			},
@@ -47,7 +53,10 @@ func TestGetDeliveredFilename(t *testing.T) {
 			"bogus-id",
 			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
 			map[string]string{
-				"filename": "test.txt",
+				"version":           "2.0",
+				"data_stream_id":    "dextesting",
+				"data_stream_route": "testevent1",
+				"filename":          "test.txt",
 			},
 			ErrBadIngestTimestamp,
 			"",

--- a/upload-server/internal/delivery/delivery_test.go
+++ b/upload-server/internal/delivery/delivery_test.go
@@ -1,10 +1,12 @@
-package delivery
+package delivery_test
 
 import (
 	"context"
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/delivery"
 )
 
 func TestGetDeliveredFilename(t *testing.T) {
@@ -45,7 +47,7 @@ func TestGetDeliveredFilename(t *testing.T) {
 				"dex_ingest_datetime": "bogus time",
 				"filename":            "test.txt",
 			},
-			ErrBadIngestTimestamp,
+			delivery.ErrBadIngestTimestamp,
 			"",
 		},
 		{
@@ -58,13 +60,13 @@ func TestGetDeliveredFilename(t *testing.T) {
 				"data_stream_route": "testevent1",
 				"filename":          "test.txt",
 			},
-			ErrBadIngestTimestamp,
+			delivery.ErrBadIngestTimestamp,
 			"",
 		},
 	}
 
 	for i, c := range testCases {
-		res, err := getDeliveredFilename(c.ctx, c.tuid, c.pathTemplate, c.manifest)
+		res, err := delivery.GetDeliveredFilename(c.ctx, c.tuid, c.pathTemplate, c.manifest)
 		if res != c.result {
 			t.Errorf("missmatched results for test case %d: got %s expected %s", i, res, c.result)
 		}

--- a/upload-server/internal/delivery/delivery_test.go
+++ b/upload-server/internal/delivery/delivery_test.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -30,6 +31,27 @@ func TestGetDeliveredFilename(t *testing.T) {
 			nil,
 			"routine-immunization-zip/2020/04/11/test.txt",
 		},
+		{
+			ctx,
+			"bogus-id",
+			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
+			map[string]string{
+				"dex_ingest_datetime": "bogus time",
+				"filename":            "test.txt",
+			},
+			ErrBadIngestTimestamp,
+			"",
+		},
+		{
+			ctx,
+			"bogus-id",
+			"routine-immunization-zip/{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}",
+			map[string]string{
+				"filename": "test.txt",
+			},
+			ErrBadIngestTimestamp,
+			"",
+		},
 	}
 
 	for i, c := range testCases {
@@ -37,7 +59,7 @@ func TestGetDeliveredFilename(t *testing.T) {
 		if res != c.result {
 			t.Errorf("missmatched results for test case %d: got %s expected %s", i, res, c.result)
 		}
-		if err != c.err {
+		if !errors.Is(err, c.err) || (c.err == nil && err != nil) {
 			t.Errorf("missmatched errors for test case %d: got %+v expected %+v", i, err, c.err)
 		}
 	}

--- a/upload-server/internal/delivery/file.go
+++ b/upload-server/internal/delivery/file.go
@@ -19,13 +19,14 @@ type FileDestination struct {
 	PathTemplate string `yaml:"path_template"`
 }
 
-func (fd *FileDestination) Upload(_ context.Context, id string, r io.Reader, m map[string]string) (string, error) {
-	if err := os.MkdirAll(fd.ToPath, 0755); err != nil {
+func (fd *FileDestination) Upload(_ context.Context, path string, r io.Reader, m map[string]string) (string, error) {
+	loc := filepath.Join(fd.ToPath, path)
+	if err := os.MkdirAll(filepath.Dir(loc), 0755); err != nil {
 		return "", err
 	}
-	dest, err := os.Create(filepath.Join(fd.ToPath, id))
+	dest, err := os.Create(loc)
 	if err != nil {
-		return dest.Name(), err
+		return path, err
 	}
 	defer dest.Close()
 	if _, err := io.Copy(dest, r); err != nil {

--- a/upload-server/internal/delivery/s3.go
+++ b/upload-server/internal/delivery/s3.go
@@ -124,23 +124,18 @@ func (sd *S3Destination) Client() *s3.Client {
 }
 
 func (sd *S3Destination) Upload(ctx context.Context, path string, r io.Reader, m map[string]string) (string, error) {
-	destFileName, err := getDeliveredFilename(ctx, path, sd.PathTemplate, m)
-	if err != nil {
-		return "", err
-	}
 
 	uploader := manager.NewUploader(sd.Client())
-	_, err = uploader.Upload(ctx, &s3.PutObjectInput{
+	if _, err := uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket:   &sd.BucketName,
-		Key:      &destFileName,
+		Key:      &path,
 		Body:     r,
 		Metadata: m,
-	})
-	if err != nil {
+	}); err != nil {
 		return "", fmt.Errorf("failed to upload file to %s %s: %w", sd.BucketName, path, err)
 	}
 
-	s3URL := fmt.Sprintf("https://%s.s3.us-east-1.amazonaws.com/%s", sd.BucketName, destFileName)
+	s3URL := fmt.Sprintf("https://%s.s3.us-east-1.amazonaws.com/%s", sd.BucketName, path)
 	return s3URL, nil
 }
 

--- a/upload-server/internal/event/event.go
+++ b/upload-server/internal/event/event.go
@@ -30,6 +30,7 @@ type FileReady struct {
 	Event
 	UploadId          string `json:"upload_id"`
 	SrcUrl            string `json:"src_url"`
+	Path              string `json:"path"`
 	DestinationTarget string `json:"deliver_target"`
 	Metadata          map[string]string
 }
@@ -58,11 +59,12 @@ func (fr *FileReady) Identifier() string {
 	return fr.UploadId
 }
 
-func NewFileReadyEvent(uploadId string, metadata map[string]string, target string) *FileReady {
+func NewFileReadyEvent(uploadId string, metadata map[string]string, path, target string) *FileReady {
 	return &FileReady{
 		Event: Event{
 			Type: FileReadyEventType,
 		},
+		Path:              path,
 		UploadId:          uploadId,
 		Metadata:          metadata,
 		DestinationTarget: target,

--- a/upload-server/internal/metadata/metadata.go
+++ b/upload-server/internal/metadata/metadata.go
@@ -182,40 +182,6 @@ func GetVersion(manifest handler.MetaData) string {
 	return version
 }
 
-func GetFilenamePrefix(ctx context.Context, manifest handler.MetaData) (string, error) {
-	config, err := GetConfigFromManifest(ctx, manifest)
-	if err != nil {
-		return "", err
-	}
-
-	ds := metadata.GetDataStreamID(manifest)
-	r := metadata.GetDataStreamRoute(manifest)
-
-	p := ds + "-" + r
-
-	if config.Copy.FolderStructure == FolderStructureDate {
-		// Get UTC year, month, and day
-		t := time.Now().UTC()
-		datePrefix := fmt.Sprintf("%d/%02d/%02d", t.Year(), t.Month(), t.Day())
-		p = p + "/" + datePrefix
-	}
-
-	return p, nil
-}
-
-func GetFilenameSuffix(ctx context.Context, manifest handler.MetaData, tuid string) (string, error) {
-	s := ""
-	c, err := GetConfigFromManifest(ctx, manifest)
-	if err != nil {
-		return s, err
-	}
-	if c.Copy.FilenameSuffix == FilenameSuffixUploadId {
-		s = "_" + tuid
-	}
-
-	return s, nil
-}
-
 func Uid() string {
 	return uuid.NewString()
 }

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -67,7 +67,7 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 		})
 		return err
 	}
-	uri, err := delivery.Deliver(ctx, e.UploadId, src, d)
+	uri, err := delivery.Deliver(ctx, e.UploadId, e.Path, src, d)
 
 	if err != nil {
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -192,8 +192,8 @@ func TestTus(t *testing.T) {
 				for target, path := range AllTargets {
 					if slices.Contains(config.Copy.Targets, target) {
 						// Check that the file exists in the target checkpoint folder
-						if _, err := os.Stat(path + "/" + tuid); errors.Is(err, os.ErrNotExist) {
-							t.Error("file was not copied to "+target+" checkpoint for file", tuid)
+						if _, err := os.Stat(path + "/" + tuid + ".txt"); errors.Is(err, os.ErrNotExist) {
+							t.Error("file was not copied to "+target+" checkpoint for file", tuid, name)
 						}
 					}
 				}
@@ -217,12 +217,12 @@ func TestRouteEndpoint(t *testing.T) {
 			t.Error("could not create tuid")
 		} else {
 			// Check that the file exists in the target checkpoint folder
-			if _, err := os.Stat(TestEDAVFolder + "/" + tuid); errors.Is(err, os.ErrNotExist) {
+			if _, err := os.Stat(TestEDAVFolder + "/" + tuid + ".txt"); errors.Is(err, os.ErrNotExist) {
 				t.Error("file was not copied to edav checkpoint for file", tuid)
 			}
 
 			// Remove and re-route the file
-			err = os.Remove(TestEDAVFolder + "/" + tuid)
+			err = os.Remove(TestEDAVFolder + "/" + tuid + ".txt")
 			if err != nil {
 				t.Error("failed to remove edav file for "+tuid, err.Error())
 			}
@@ -238,7 +238,7 @@ func TestRouteEndpoint(t *testing.T) {
 				t.Error("expected 200 when retrying route but got", resp.StatusCode, string(b))
 			}
 			time.Sleep(100 * time.Millisecond) // Wait for new file ready event to be processed.
-			if _, err := os.Stat(TestEDAVFolder + "/" + tuid); errors.Is(err, os.ErrNotExist) {
+			if _, err := os.Stat(TestEDAVFolder + "/" + tuid + ".txt"); errors.Is(err, os.ErrNotExist) {
 				t.Error("file was not copied to edav checkpoint when retry attempted for file", tuid)
 			}
 		}

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/delivery"
 	"io"
 	"log"
 	"net/http"
@@ -20,11 +19,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cdcgov/data-exchange-upload/upload-server/internal/delivery"
+
 	"github.com/cdcgov/data-exchange-upload/upload-server/cmd/cli"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata"
-	"github.com/cdcgov/data-exchange-upload/upload-server/internal/metadata/validation"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/postprocessing"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/ui"
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/reports"
@@ -279,103 +279,6 @@ func TestRequiredUploadIdEndpoints(t *testing.T) {
 		if resp.StatusCode != 404 {
 			t.Error("bad response for ", endpoint, resp.StatusCode)
 		}
-	}
-}
-
-func TestGetFileDeliveryPrefixDate(t *testing.T) {
-	ctx := context.TODO()
-	m := map[string]string{
-		"version":           "2.0",
-		"data_stream_id":    "test-stream",
-		"data_stream_route": "test-route",
-	}
-	metadata.Cache.SetConfig("v2/test-stream_test-route.json", &validation.ManifestConfig{
-		Copy: validation.CopyConfig{
-			FolderStructure: metadata.FolderStructureDate,
-		},
-	})
-
-	p, err := metadata.GetFilenamePrefix(ctx, m)
-	if err != nil {
-		t.Fatal(err)
-	}
-	prefixTokens := strings.Split(p, "/")
-	if len(prefixTokens) != 4 {
-		t.Error("prefix not properly formatted", p)
-	}
-	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
-	if prefixTokens[0] != expectedFolderPrefix {
-		t.Error("prefix folder not properly formatted")
-	}
-}
-
-func TestGetFileDeliveryPrefixRoot(t *testing.T) {
-	ctx := context.TODO()
-	m := map[string]string{
-		"version":           "2.0",
-		"data_stream_id":    "test-stream",
-		"data_stream_route": "test-route",
-	}
-	metadata.Cache.SetConfig("v2/test-stream_test-route.json", &validation.ManifestConfig{
-		Copy: validation.CopyConfig{
-			FolderStructure: metadata.FolderStructureRoot,
-		},
-	})
-
-	p, err := metadata.GetFilenamePrefix(ctx, m)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedFolderPrefix := m["data_stream_id"] + "-" + m["data_stream_route"]
-
-	if p != expectedFolderPrefix {
-		t.Error("expected file delivery prefix to be folder prefix but was", p)
-	}
-}
-
-func TestDeliveryFilenameSuffixUploadId(t *testing.T) {
-	ctx := context.TODO()
-	m := map[string]string{
-		"version":           "2.0",
-		"data_stream_id":    "test-stream",
-		"data_stream_route": "test-route",
-	}
-	tuid := "1234"
-	metadata.Cache.SetConfig("v2/test-stream_test-route.json", &validation.ManifestConfig{
-		Copy: validation.CopyConfig{
-			FilenameSuffix: metadata.FilenameSuffixUploadId,
-		},
-	})
-
-	s, err := metadata.GetFilenameSuffix(ctx, m, tuid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s != "_"+tuid {
-		t.Error("expected upload ID suffix but get", s)
-	}
-}
-
-func TestDeliveryFilenameSuffixNone(t *testing.T) {
-	ctx := context.TODO()
-	m := map[string]string{
-		"version":           "2.0",
-		"data_stream_id":    "test-stream",
-		"data_stream_route": "test-route",
-	}
-	tuid := "1234"
-	metadata.Cache.SetConfig("v2/test-stream_test-route.json", &validation.ManifestConfig{
-		Copy: validation.CopyConfig{
-			FilenameSuffix: "",
-		},
-	})
-
-	s, err := metadata.GetFilenameSuffix(ctx, m, tuid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s != "" {
-		t.Error("expected empty suffix but get", s)
 	}
 }
 

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -32,6 +32,7 @@ routing_groups:
     data_stream_route: fhir
     delivery_targets:
       - name: eicr
+        path_template: "{{.UploadId}}"
   - data_stream_id: rsp-prevention
     data_stream_route: csv
     delivery_targets:
@@ -56,10 +57,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.UploadId}}"
       - name: eicr
-        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.UploadId}}"
       - name: edav
-        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.UploadId}}"
       - name: ehdi
-        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.UploadId}}"

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -56,10 +56,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
-        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
+        path_template: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -23,6 +23,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
+        path_template: "{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:

--- a/upload-server/testing/delivery.yml
+++ b/upload-server/testing/delivery.yml
@@ -23,7 +23,7 @@ routing_groups:
     data_stream_route: localsequencefile
     delivery_targets:
       - name: edav
-        path_template: "{{.Filename}}"
+        path_template: "{{.DataStreamID}}/{{.DataStreamRoute}}/{{.Filename}}"
   - data_stream_id: ehdi
     data_stream_route: csv
     delivery_targets:
@@ -56,6 +56,10 @@ routing_groups:
     data_stream_route: testevent1
     delivery_targets:
       - name: ncird
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: eicr
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: edav
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"
       - name: ehdi
+        pathTemplate: "{{.Year}}/{{.Month}}/{{.Day}}/{{.Filename}}_{{.UploadId}}"


### PR DESCRIPTION
before this the current time at delivery was used to construct the destination path. This changes that to use the time the file submission started from the sender.