### PR TITLE
Updating NCIRD targets for tests and handling + symbol

### DIFF
--- a/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
+++ b/tests/smoke/kotlin/src/test/kotlin/FileCopy.kt
@@ -60,7 +60,8 @@ class FileCopy {
         val currentDateTime = ZonedDateTime.now(TimeZone.getTimeZone("GMT").toZoneId())
         uploadInfo.deliveries?.forEach { delivery ->
             Assert.assertEquals(delivery.status, "SUCCESS") // remove the assertion above?
-            val actualLocation = URLDecoder.decode(delivery.location, StandardCharsets.UTF_8.toString())
+            val encodedLocation = delivery.location.replace("+", "%2B")
+            val actualLocation = URLDecoder.decode(encodedLocation, StandardCharsets.UTF_8.toString())
             val pattern = case.deliveryTargets?.find{ it.name == delivery.name}?.pathTemplate?.get(EnvConfig.ENVIRONMENT)
             val expectedLocation = pattern
                 ?.replace("{dataStream}", case.manifest["data_stream_id"].toString())

--- a/tests/smoke/kotlin/src/test/resources/valid_manifests.json
+++ b/tests/smoke/kotlin/src/test/resources/valid_manifests.json
@@ -38,7 +38,7 @@
         "name": "ncird",
         "path_template": {
           "LOCAL": "/upload/ncird/{uid}",
-          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }
@@ -63,7 +63,7 @@
         "name": "ncird",
         "path_template": {
           "LOCAL": "/upload/ncird/{uid}",
-          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }
@@ -88,7 +88,7 @@
         "name": "ncird",
         "path_template": {
           "LOCAL": "/dex-test/routine-immunization-zip/{year}/{month}/{day}/{filename}",
-          "DEV": "/dex-dev/routine-immunization-zip/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex/routine-immunization-zip/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/routine-immunization-zip/{year}/{month}/{day}/{filename}",
           "STAGE": "/dex/routine-immunization-zip/{year}/{month}/{day}/{filename}"
         }
@@ -113,7 +113,7 @@
         "name": "ncird",
         "path_template": {
           "LOCAL": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
-          "DEV": "/dex-dev/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
+          "DEV": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "TEST": "/dex-test/{dataStream}-{route}/{year}/{month}/{day}/{filename}",
           "STAGE": "/dex/{dataStream}-{route}/{year}/{month}/{day}/{filename}"
         }


### PR DESCRIPTION
TestNG test config fixes

- Changing the NCIRD targets for the DEV environment
- Handling `+` symbol in the actual file locations so they don't get converted to spaces