### PR TITLE
only expect edav delivery target for dextesing

### DIFF
--- a/tests/bad-uploader/config.go
+++ b/tests/bad-uploader/config.go
@@ -30,7 +30,6 @@ var (
 	patchURL    string
 
 	manifest = JSONVar{
-		"version":           "2.0",
 		"data_stream_id":    "dextesting",
 		"data_stream_route": "testevent1",
 		"received_filename": "test",
@@ -38,7 +37,7 @@ var (
 		"data_producer_id":  "dex simulation harness",
 		"jurisdiction":      "test",
 	}
-	manifestTargets = []string{"edav", "eicr", "ehdi", "ncird"}
+	manifestTargets = []string{"edav"}
 
 	testcase TestCase
 	cases    TestCases


### PR DESCRIPTION
Due to a recent update in the configuration, the dextesting use case will only be delivered to the dex edav target.  This patch updates the load test to reflect that.