### PR TITLE
flag for info endpoint

### DIFF
--- a/tests/bad-uploader/info.go
+++ b/tests/bad-uploader/info.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	neturl "net/url"
-	"path"
 	"slices"
 	"sync/atomic"
 )
@@ -43,8 +42,7 @@ type InfoChecker struct {
 }
 
 func (ic *InfoChecker) DoCase(ctx context.Context, c TestCase, uploadId string) error {
-	serverUrl, _ := path.Split(url)
-	infoUrl, err := neturl.JoinPath(serverUrl, "info", uploadId)
+	infoUrl, err := neturl.JoinPath(infoUrl, uploadId)
 	if err != nil {
 		return err
 	}

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -139,8 +139,9 @@ func worker(c <-chan TestCase, o chan<- *Result, conf *config) {
 		res, err := runTest(e, conf)
 		if err != nil {
 			slog.Error("ERROR: ", "error", err, "case", e)
+		} else {
+			atomic.AddInt32(&testResult.SuccessfulUploads, 1)
 		}
-		atomic.AddInt32(&testResult.SuccessfulUploads, 1)
 		o <- res
 	}
 }


### PR DESCRIPTION
Adds an optional flag for the upload info endpoint.  This is to cover the case where the info endpoint has the same subpath as the upload endpoint.  This is the case with the public URLs for the Upload API.  The upload endpoint is `https://api.cdc.gov/upload` and the info endpoint is `https://api.cdc.gov/upload/info`.  The script was erroniously checking the info endpoint at `https://api.cdc.gov/info` as it assumed the info endpoint was on a different subpath than the upload endpoint.  However, for the public URLs of the Upload API, that is not the case.

If no value for this new flag is provided, it will default to using the value provided for the `url` flag.