### PR TITLE
Bad uploader exit code

### DIFF
--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -41,7 +41,7 @@ func main() {
 	err = ValidateResults(ctx, o)
 	testResult.TotalDuration = time.Since(tStart)
 	PrintFinalReport(err)
-
+	exitError(err)
 }
 
 func StartWorkers(c <-chan TestCase) <-chan *Result {
@@ -173,5 +173,14 @@ func logErrors(err error, uploadId string) {
 	defer f.Close()
 	if _, e = f.WriteString(err.Error()); e != nil {
 		panic(e)
+	}
+}
+
+func exitError(validationErrors error) {
+	unsuccessfulUploads := load > 0 && testResult.SuccessfulUploads < int32(load)
+	unsuccessfulDeliveries := testResult.SuccessfulDeliveries < testResult.SuccessfulUploads
+	if validationErrors != nil || unsuccessfulUploads || unsuccessfulDeliveries {
+		fmt.Println("FAILED")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This patch tells the bad uploader to return a non-zero exit code if upload or validation errors occurred.  This is to help notify CD pipelines that something bad has happened, and the job should ultimately be failed.