### PR TITLE
Use uploadID prefix (s3 only) for reports

### DIFF
--- a/upload-server/pkg/fileinspector/status.go
+++ b/upload-server/pkg/fileinspector/status.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/event"
@@ -20,6 +21,7 @@ type FileSystemUploadStatusInspector struct {
 }
 
 func (fsusi *FileSystemUploadStatusInspector) InspectFileDeliveryStatus(_ context.Context, id string) ([]info.FileDeliveryStatus, error) {
+	id, _, _ = strings.Cut(id, "+")
 	deliveries := []info.FileDeliveryStatus{}
 	deliveryReportFilename := filepath.Join(fsusi.ReportsDir, id+event.TypeSeparator+reports.StageFileCopy)
 	f, err := os.Open(deliveryReportFilename)
@@ -64,6 +66,7 @@ func (fsusi *FileSystemUploadStatusInspector) InspectFileDeliveryStatus(_ contex
 }
 
 func (fsusi *FileSystemUploadStatusInspector) InspectFileUploadStatus(ctx context.Context, id string) (info.FileUploadStatus, error) {
+	id, _, _ = strings.Cut(id, "+")
 	// check if the upload-completed file exists
 	uploadCompletedReportFilename := filepath.Join(fsusi.ReportsDir, id+event.TypeSeparator+reports.StageUploadCompleted)
 	uploadCompletedFileInfo, err := os.Stat(uploadCompletedReportFilename)

--- a/upload-server/pkg/reports/builder.go
+++ b/upload-server/pkg/reports/builder.go
@@ -2,6 +2,7 @@ package reports
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus"
@@ -145,6 +146,7 @@ type Builder[T any] interface {
 }
 
 func NewBuilder[T any](version string, action string, uploadId string, dispType string) Builder[T] {
+	uploadId, _, _ = strings.Cut(uploadId, "+")
 	return &ReportBuilder[T]{
 		Version:         version,
 		Action:          action,
@@ -157,6 +159,7 @@ func NewBuilder[T any](version string, action string, uploadId string, dispType 
 }
 
 func NewBuilderWithManifest[T any](version string, action string, uploadId string, manifest map[string]string, dispType string) Builder[T] {
+	uploadId, _, _ = strings.Cut(uploadId, "+")
 	return &ReportBuilder[T]{
 		Version:         version,
 		Action:          action,
@@ -188,7 +191,6 @@ func (b *ReportBuilder[T]) SetAction(s string) Builder[T] {
 }
 
 func (b *ReportBuilder[T]) SetUploadId(id string) Builder[T] {
-	b.UploadId = id
 	return b
 }
 


### PR DESCRIPTION
Before this reports in the aws environment were split between those with the TUS upload ID and the TUS ID + s3 multipart