### PR TITLE
PHDO-153 Decode destination URL from Azure destinations

### DIFF
--- a/upload-server/internal/delivery/azure.go
+++ b/upload-server/internal/delivery/azure.go
@@ -3,6 +3,7 @@ package delivery
 import (
 	"context"
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
@@ -106,7 +107,13 @@ func (ad *AzureDestination) Upload(ctx context.Context, path string, r io.Reader
 	_, err = client.UploadStream(ctx, r, &azblob.UploadStreamOptions{
 		Metadata: storeaz.PointerizeMetadata(m),
 	})
-	return client.URL(), err
+
+	decodedUrl, err := url.QueryUnescape(client.URL())
+	if err != nil {
+		return "", err
+	}
+
+	return decodedUrl, err
 }
 
 func (ad *AzureDestination) Health(ctx context.Context) (rsp models.ServiceHealthResp) {


### PR DESCRIPTION
This patch handles the URL encoding that the Azure blob client does when created.  When given a blob name, the blob client creates a URL property within its instance.  When this happens, the blob name gets URL encoded.  Therefore, when the URL property was used for reporting purposes, it was showing the URL encoded string.  This patch handles this by decoding the URL before returning it to the caller.