### PR TITLE
adding test values to data stream configs

### DIFF
--- a/upload-configs/ehdi_csv.json
+++ b/upload-configs/ehdi_csv.json
@@ -29,7 +29,8 @@
           "NJ-PHA",
           "ND-PHA",
           "NE-PHA",
-          "MI-PHA"
+          "MI-PHA",
+          "PHDO-USER"
         ],
         "description": "This field is the identifier for the sender of the data."
       },
@@ -45,7 +46,8 @@
           "NJ-PHA",
           "ND-PHA",
           "NE-PHA",
-          "MI-PHA"
+          "MI-PHA",
+          "PHDO-USER"
         ],
         "description": "This field is the identifier for the data producer."
       },
@@ -61,7 +63,8 @@
           "NJ",
           "ND",
           "NE",
-          "MI"
+          "MI",
+          "XX"
         ],
         "description": "This field indicates the jurisdiction associated with the data. If not provided, populate with null."
       },

--- a/upload-configs/eicr_fhir.json
+++ b/upload-configs/eicr_fhir.json
@@ -5,7 +5,8 @@
 				"field_name": "sender_id",
 				"required": true,
 				"allowed_values": [
-					"APHL"
+					"APHL",
+					"PHDO-USER"
 				],
 				"description": "This field is the identifier for the sender of the data."
 			},

--- a/upload-configs/pulsenet_localsequencefile.json
+++ b/upload-configs/pulsenet_localsequencefile.json
@@ -5,7 +5,8 @@
             "field_name": "sender_id",
             "required": true,
             "allowed_values": [
-               "PulseNet-App"
+               "PulseNet-App",
+               "PHDO-USER"
             ],
             "description": "This field is the identifier for the sender of the data."
          },


### PR DESCRIPTION
## Updates

- Added value `PHDO-USER` to PulseNet config sender-id metadata allowed value list
- Added value `PHDO-USER` to eICR config sender-id metadata allowed value list
- Added value `PHDO-USER` to EHDI config sender-id and data-producer-id metadata allowed value list
- Added value `XX` to EHDI config jurisdiction metadata allowed value list