### PR TITLE
fixup/handle error from upload stream

### DIFF
--- a/upload-server/internal/delivery/azure.go
+++ b/upload-server/internal/delivery/azure.go
@@ -107,6 +107,9 @@ func (ad *AzureDestination) Upload(ctx context.Context, path string, r io.Reader
 	_, err = client.UploadStream(ctx, r, &azblob.UploadStreamOptions{
 		Metadata: storeaz.PointerizeMetadata(m),
 	})
+	if err != nil {
+		return "", err
+	}
 
 	decodedUrl, err := url.QueryUnescape(client.URL())
 	if err != nil {

--- a/upload-server/internal/delivery/azure.go
+++ b/upload-server/internal/delivery/azure.go
@@ -104,19 +104,19 @@ func (ad *AzureDestination) Upload(ctx context.Context, path string, r io.Reader
 	}
 	client := c.NewBlockBlobClient(path)
 
+	decodedUrl, err := url.QueryUnescape(client.URL())
+	if err != nil {
+		return client.URL(), err
+	}
+
 	_, err = client.UploadStream(ctx, r, &azblob.UploadStreamOptions{
 		Metadata: storeaz.PointerizeMetadata(m),
 	})
 	if err != nil {
-		return "", err
+		return decodedUrl, err
 	}
 
-	decodedUrl, err := url.QueryUnescape(client.URL())
-	if err != nil {
-		return "", err
-	}
-
-	return decodedUrl, err
+	return decodedUrl, nil
 }
 
 func (ad *AzureDestination) Health(ctx context.Context) (rsp models.ServiceHealthResp) {

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -63,7 +63,7 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	uri, err := delivery.Deliver(ctx, e.UploadId, e.Path, src, d)
 
 	if err != nil {
-		slog.Error("failed to deliver file", "error", err)
+		slog.Error("failed to deliver file", "target", uri, "error", err)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{
 			Level:   reports.IssueLevelError,
 			Message: err.Error(),

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -63,6 +63,7 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	uri, err := delivery.Deliver(ctx, e.UploadId, e.Path, src, d)
 
 	if err != nil {
+		slog.Error("failed to deliver file", "error", err)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{
 			Level:   reports.IssueLevelError,
 			Message: err.Error(),


### PR DESCRIPTION
small patch to handle error produced by the azure upload stream response.  Previously, this error was being ignored, which potentially led to deliveries reporting successful delivery when the upload stream request produced an error, such as a timeout.

This doesn't fix the errors themselves, but will at least let us catch them when they happen, and report a delivery failure instead of a success.