### PR TITLE
Fixup/auth middleware and tus cors

### DIFF
--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -75,7 +75,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware *m
 	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook)
 
 	// initialize tusd handler
-	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath, appConfig.OauthConfig.AuthEnabled)
+	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath)
 	if err != nil {
 		logger.Error("error starting tusd handler: ", "error", err)
 		return nil, err

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -75,7 +75,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware *m
 	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook)
 
 	// initialize tusd handler
-	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath)
+	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath, appConfig.OauthConfig.AuthEnabled)
 	if err != nil {
 		logger.Error("error starting tusd handler: ", "error", err)
 		return nil, err

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -17,7 +17,7 @@ import (
 	"github.com/tus/tusd/v2/pkg/memorylocker"
 )
 
-func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware middleware.AuthMiddleware) (http.Handler, error) {
+func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware *middleware.AuthMiddleware) (http.Handler, error) {
 	if sloger.DefaultLogger != nil {
 		logger = sloger.DefaultLogger
 	}

--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -103,7 +103,7 @@ func main() {
 		}()
 	}
 
-	authMiddleware, err := middleware.NewAuthMiddleware(*appConfig.OauthConfig)
+	authMiddleware, err := middleware.NewAuthMiddleware(ctx, *appConfig.OauthConfig)
 	if err != nil {
 		slog.Error("error starting app, error initialize auth middleware", "error", err)
 		os.Exit(appMainExitCode)

--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -104,9 +104,12 @@ func main() {
 	}
 
 	authMiddleware, err := middleware.NewAuthMiddleware(ctx, *appConfig.OauthConfig)
-
+	if err != nil {
+		slog.Error("error starting app, error initialize auth middleware", "error", err)
+		os.Exit(appMainExitCode)
+	}
 	// start serving the app
-	handler, err := cli.Serve(ctx, appConfig, *authMiddleware)
+	handler, err := cli.Serve(ctx, appConfig, authMiddleware)
 	if err != nil {
 		slog.Error("error starting app, error initialize dex handler", "error", err)
 		os.Exit(appMainExitCode)
@@ -141,7 +144,7 @@ func main() {
 		mainWaitGroup.Add(1)
 		go func() {
 			defer mainWaitGroup.Done()
-			if err := ui.Start(appConfig.UIPort, appConfig.CsrfToken, appConfig.ExternalServerFileEndpointUrl, appConfig.InternalServerInfoEndpointUrl, appConfig.InternalServerFileEndpointUrl, *authMiddleware); err != nil {
+			if err := ui.Start(appConfig.UIPort, appConfig.CsrfToken, appConfig.ExternalServerFileEndpointUrl, appConfig.InternalServerInfoEndpointUrl, appConfig.InternalServerFileEndpointUrl, authMiddleware); err != nil {
 				slog.Error("failed to start ui", "error", err)
 				os.Exit(appMainExitCode)
 			}

--- a/upload-server/cmd/main.go
+++ b/upload-server/cmd/main.go
@@ -103,7 +103,7 @@ func main() {
 		}()
 	}
 
-	authMiddleware, err := middleware.NewAuthMiddleware(ctx, *appConfig.OauthConfig)
+	authMiddleware, err := middleware.NewAuthMiddleware(*appConfig.OauthConfig)
 	if err != nil {
 		slog.Error("error starting app, error initialize auth middleware", "error", err)
 		os.Exit(appMainExitCode)

--- a/upload-server/internal/handlertusd/handlertusd.go
+++ b/upload-server/internal/handlertusd/handlertusd.go
@@ -30,7 +30,7 @@ type Locker interface {
 }
 
 // New returns a configured TUSD handler as-is with official implementation
-func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath string) (*tusd.Handler, error) {
+func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath string, enableCORS bool) (*tusd.Handler, error) {
 	if slogerxexp.DefaultLogger != nil {
 		logger = slogerxexp.DefaultLogger
 	}
@@ -62,11 +62,11 @@ func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath st
 		RespectForwardedHeaders: true,
 		DisableDownload:         true,
 		Cors: &tusd.CorsConfig{
-			Disable:          false,
+			Disable:          !enableCORS,
 			AllowCredentials: true,
 			AllowOrigin:      regexp.MustCompile(".*"),
-			AllowHeaders:     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version",
-			ExposeHeaders:    "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version",
+			AllowHeaders:     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version, Location, Tus-Version, Tus-Max-Size, Tus-Extension",
+			ExposeHeaders:    "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version, Location, Tus-Version, Tus-Max-Size, Tus-Extension",
 			AllowMethods:     "POST, HEAD, PATCH, OPTIONS, GET, DELETE",
 			MaxAge:           "86400",
 		},

--- a/upload-server/internal/handlertusd/handlertusd.go
+++ b/upload-server/internal/handlertusd/handlertusd.go
@@ -2,15 +2,13 @@ package handlertusd
 
 import (
 	"errors"
-	"golang.org/x/exp/slog"
-	"os"
-	"regexp"
-
 	"github.com/cdcgov/data-exchange-upload/upload-server/pkg/slogerxexp"
 	"github.com/prometheus/client_golang/prometheus"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
 	"github.com/tus/tusd/v2/pkg/prometheuscollector"
+	"golang.org/x/exp/slog"
+	"os"
 ) // .import
 
 var logger *slog.Logger
@@ -30,7 +28,7 @@ type Locker interface {
 }
 
 // New returns a configured TUSD handler as-is with official implementation
-func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath string, enableCORS bool) (*tusd.Handler, error) {
+func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath string) (*tusd.Handler, error) {
 	if slogerxexp.DefaultLogger != nil {
 		logger = slogerxexp.DefaultLogger
 	}
@@ -51,6 +49,8 @@ func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath st
 	// ------------------------------------------------------------------
 	//  handler, set with respective local or cloud values
 	// ------------------------------------------------------------------
+	corsConfig := tusd.DefaultCorsConfig
+	corsConfig.AllowCredentials = true
 
 	// Create a new HTTP handler for the tusd server by providing a configuration.
 	// The StoreComposer property must be set to allow the handler to function.
@@ -61,15 +61,7 @@ func New(store Store, locker Locker, hooksHandler hooks.HookHandler, basePath st
 		Logger:                  slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
 		RespectForwardedHeaders: true,
 		DisableDownload:         true,
-		Cors: &tusd.CorsConfig{
-			Disable:          !enableCORS,
-			AllowCredentials: true,
-			AllowOrigin:      regexp.MustCompile(".*"),
-			AllowHeaders:     "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version, Location, Tus-Version, Tus-Max-Size, Tus-Extension",
-			ExposeHeaders:    "Authorization, Origin, X-Requested-With, X-Request-ID, X-HTTP-Method-Override, Content-Type, Upload-Length, Upload-Offset, Tus-Resumable, Upload-Metadata, Upload-Defer-Length, Upload-Concat, Upload-Incomplete, Upload-Complete, Upload-Draft-Interop-Version, Location, Tus-Version, Tus-Max-Size, Tus-Extension",
-			AllowMethods:     "POST, HEAD, PATCH, OPTIONS, GET, DELETE",
-			MaxAge:           "86400",
-		},
+		Cors:                    &corsConfig,
 	}, hooksHandler, []hooks.HookType{hooks.HookPreCreate, hooks.HookPostCreate, hooks.HookPostReceive, hooks.HookPreFinish, hooks.HookPostFinish, hooks.HookPostTerminate}) // .handler
 	if err != nil {
 		logger.Error("error start tusd handler", "error", err)

--- a/upload-server/internal/middleware/authverification.go
+++ b/upload-server/internal/middleware/authverification.go
@@ -46,6 +46,9 @@ func NewHTTPError(code int, msg string) *HTTPError {
 func NewAuthMiddleware(ctx context.Context, config appconfig.OauthConfig) (*AuthMiddleware, error) {
 	var validator oauth.Validator = oauth.PassthroughValidator{}
 	if config.AuthEnabled {
+		if config.IssuerUrl == "" {
+			return nil, errors.New("no issuer url provided")
+		}
 		var err error
 		validator, err = oauth.NewOAuthValidator(ctx, config.IssuerUrl, config.RequiredScopes)
 		if err != nil {

--- a/upload-server/internal/middleware/authverification.go
+++ b/upload-server/internal/middleware/authverification.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/appconfig"
 	"github.com/cdcgov/data-exchange-upload/upload-server/internal/health"
@@ -42,11 +43,11 @@ func NewHTTPError(code int, msg string) *HTTPError {
 	return &HTTPError{Code: code, Msg: msg}
 }
 
-func NewAuthMiddleware(config appconfig.OauthConfig) (*AuthMiddleware, error) {
+func NewAuthMiddleware(ctx context.Context, config appconfig.OauthConfig) (*AuthMiddleware, error) {
 	var validator oauth.Validator = oauth.PassthroughValidator{}
 	if config.AuthEnabled {
 		var err error
-		validator, err = oauth.NewOAuthValidator(config.IssuerUrl, config.RequiredScopes)
+		validator, err = oauth.NewOAuthValidator(ctx, config.IssuerUrl, config.RequiredScopes)
 		if err != nil {
 			slog.Error("error initializing oauth validator", "error", err)
 			return nil, err

--- a/upload-server/internal/middleware/authverification_test.go
+++ b/upload-server/internal/middleware/authverification_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -208,7 +207,6 @@ func TestVerifyOAuthTokenMiddleware_TestCases(t *testing.T) {
 func runOAuthTokenVerificationTestCase(t *testing.T, tc testCase) {
 
 	t.Run(tc.name, func(t *testing.T) {
-		ctx := context.Background()
 		// create handler for middleware
 		hasBeenCalled := false
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -216,7 +214,7 @@ func runOAuthTokenVerificationTestCase(t *testing.T, tc testCase) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware, err := NewAuthMiddleware(ctx, appconfig.OauthConfig{
+		middleware, err := NewAuthMiddleware(appconfig.OauthConfig{
 			AuthEnabled:    tc.authEnabled,
 			IssuerUrl:      tc.issuerURL,
 			RequiredScopes: tc.requiredScopes,
@@ -367,7 +365,7 @@ func runUserSessionMiddlewareTestCase(t *testing.T, tc testCase) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware, err := NewAuthMiddleware(context.Background(), appconfig.OauthConfig{
+		middleware, err := NewAuthMiddleware(appconfig.OauthConfig{
 			AuthEnabled:    tc.authEnabled,
 			IssuerUrl:      tc.issuerURL,
 			RequiredScopes: tc.requiredScopes,

--- a/upload-server/internal/middleware/authverification_test.go
+++ b/upload-server/internal/middleware/authverification_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -214,7 +215,7 @@ func runOAuthTokenVerificationTestCase(t *testing.T, tc testCase) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware, err := NewAuthMiddleware(appconfig.OauthConfig{
+		middleware, err := NewAuthMiddleware(context.Background(), appconfig.OauthConfig{
 			AuthEnabled:    tc.authEnabled,
 			IssuerUrl:      tc.issuerURL,
 			RequiredScopes: tc.requiredScopes,
@@ -365,7 +366,7 @@ func runUserSessionMiddlewareTestCase(t *testing.T, tc testCase) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		middleware, err := NewAuthMiddleware(appconfig.OauthConfig{
+		middleware, err := NewAuthMiddleware(context.Background(), appconfig.OauthConfig{
 			AuthEnabled:    tc.authEnabled,
 			IssuerUrl:      tc.issuerURL,
 			RequiredScopes: tc.requiredScopes,

--- a/upload-server/internal/ui/ui.go
+++ b/upload-server/internal/ui/ui.go
@@ -126,7 +126,7 @@ type UploadTemplateData struct {
 
 var StaticHandler = http.FileServer(http.FS(content))
 
-func NewServer(port string, csrfToken string, externalUploadUrl string, externalInfoUrl string, internalUploadUrl string, authMiddleware middleware.AuthMiddleware) (*http.Server, error) {
+func NewServer(port string, csrfToken string, externalUploadUrl string, externalInfoUrl string, internalUploadUrl string, authMiddleware *middleware.AuthMiddleware) (*http.Server, error) {
 	router := GetRouter(externalUploadUrl, externalInfoUrl, internalUploadUrl, authMiddleware)
 	secureRouter := csrf.Protect(
 		[]byte(csrfToken),
@@ -142,7 +142,7 @@ func NewServer(port string, csrfToken string, externalUploadUrl string, external
 	return s, nil
 }
 
-func GetRouter(externalUploadUrl string, internalInfoUrl string, internalUploadUrl string, authMiddleware middleware.AuthMiddleware) *mux.Router {
+func GetRouter(externalUploadUrl string, internalInfoUrl string, internalUploadUrl string, authMiddleware *middleware.AuthMiddleware) *mux.Router {
 	router := mux.NewRouter()
 	protectedRouter := router.PathPrefix("/").Subrouter()
 	protectedRouter.Use(authMiddleware.VerifyUserSession)
@@ -382,7 +382,7 @@ func GetRouter(externalUploadUrl string, internalInfoUrl string, internalUploadU
 
 var DefaultServer *http.Server
 
-func Start(uiPort string, csrfToken string, externalUploadURL string, internalInfoURL string, internalUploadUrl string, authMiddleware middleware.AuthMiddleware) error {
+func Start(uiPort string, csrfToken string, externalUploadURL string, internalInfoURL string, internalUploadUrl string, authMiddleware *middleware.AuthMiddleware) error {
 	DefaultServer, err := NewServer(uiPort, csrfToken, externalUploadURL, internalInfoURL, internalUploadUrl, authMiddleware)
 	if err != nil {
 		return err

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -579,7 +579,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	serveHandler, err := cli.Serve(testContext, appConfig, *authMiddleware)
+	serveHandler, err := cli.Serve(testContext, appConfig, authMiddleware)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -587,7 +587,7 @@ func TestMain(m *testing.M) {
 	ts = httptest.NewServer(serveHandler)
 
 	// Start ui server
-	uiHandler := ui.GetRouter(ts.URL+appConfig.TusdHandlerBasePath, ts.URL+appConfig.TusdHandlerInfoPath, ts.URL+appConfig.TusdHandlerBasePath, *authMiddleware)
+	uiHandler := ui.GetRouter(ts.URL+appConfig.TusdHandlerBasePath, ts.URL+appConfig.TusdHandlerInfoPath, ts.URL+appConfig.TusdHandlerBasePath, authMiddleware)
 	testUIServer = httptest.NewServer(uiHandler)
 
 	testRes := m.Run()

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -574,7 +574,7 @@ func TestMain(m *testing.M) {
 		testWaitGroup.Done()
 	}()
 
-	authMiddleware, err := middleware.NewAuthMiddleware(testContext, *appConfig.OauthConfig)
+	authMiddleware, err := middleware.NewAuthMiddleware(*appConfig.OauthConfig)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -574,7 +574,7 @@ func TestMain(m *testing.M) {
 		testWaitGroup.Done()
 	}()
 
-	authMiddleware, err := middleware.NewAuthMiddleware(*appConfig.OauthConfig)
+	authMiddleware, err := middleware.NewAuthMiddleware(testContext, *appConfig.OauthConfig)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Patch to improve auth capabilities.  Namely making sure server doesn't fall over if issuer not available, better error handling of middleware init, and improve cors config for tusd to not break existing browser clients.  In addition, add healthcheck for the oidc provider