### PR TITLE
Phdo 550/auth docs

### DIFF
--- a/upload-server/docs/env-configs.md
+++ b/upload-server/docs/env-configs.md
@@ -205,14 +205,6 @@ Uses the same authentication defined for the [S3 bucket](#s3-storage-configs)
 | `EHDI_S3_ENDPOINT`    | Yes      | None          | s3-compatible storage endpoint URL for EHDI delivery storage, must start with `http` or `https` |
 | `EHDI_S3_BUCKET_NAME` | Yes      | None          | Bucket name for EHDI delivery storage                                                           |
 
-### EICR Delivery Target
-
-#### Local File System EICR Directory
-
-| Variable Name       | Required | Default Value    | Description                                            |
-|---------------------|----------|------------------|--------------------------------------------------------|
-| `LOCAL_EICR_FOLDER` | No       | `./uploads/eicr` | Relative file system path to the EICR target directory |
-
 ### NCIRD Delivery Target
 
 #### Local File System NCIRD Directory

--- a/upload-server/docs/env-configs.md
+++ b/upload-server/docs/env-configs.md
@@ -58,6 +58,8 @@ OAuth token verification is used to secure the `/files/` and `/info/` UPLOAD API
 | `OAUTH_AUTH_ENABLED`      | Yes      | `false`       | Enable or disable OAuth token verification           |
 | `OAUTH_ISSUER_URL`        | Yes      | None          | URL of the OAuth token issuer                        |
 | `OAUTH_REQUIRED_SCOPES`   | Yes      | None          | Space-separated list of required scopes              |
+| `OAUTH_SESSION_KEY`       | Yes      | None          | Unique value to be used to hash a user session cookie.  Recommended to be at least 32 bytes long.  **Value is sensative and should not be checked into source control.**              |
+| `OAUTH_SESSION_DOMAIN`    | No       | None          | Value used to set the Domain setting of the user session cookie.  Useful when the server and UI are on different subdomains.              |
 | `OAUTH_INTROSPECTION_URL` | No       | None          | URL for OAuth introspection (used for opaque tokens) |
 
 ## Upload Location Configs
@@ -210,27 +212,6 @@ Uses the same authentication defined for the [S3 bucket](#s3-storage-configs)
 | Variable Name       | Required | Default Value    | Description                                            |
 |---------------------|----------|------------------|--------------------------------------------------------|
 | `LOCAL_EICR_FOLDER` | No       | `./uploads/eicr` | Relative file system path to the EICR target directory |
-
-#### Azure EICR Container
-
-| Variable Name                    | Required | Default Value     | Description                                                         |
-|----------------------------------|----------|-------------------|---------------------------------------------------------------------|
-| `EICR_STORAGE_ACCOUNT`           | Yes      | None              | Azure EICR delivery storage account name                            |
-| `EICR_STORAGE_KEY`               | Yes      | None              | Azure EICR delivery storage account private access key or SAS token |
-| `EICR_ENDPOINT`                  | Yes      | None              | Azure EICR delivery storage endpoint URL                            |
-| `EICR_CHECKPOINT_CONTAINER_NAME` | No       | `eicr-checkpoint` | Container name for EICR delivery storage checkpoint data            |
-| `EICR_TENANT_ID`                 | No       | None              | EICR delivery account service principal tenant id                   |
-| `EICR_CLIENT_ID`                 | No       | None              | EICR delivery account service principal client id                   |
-| `EICR_CLIENT_SECRET`             | No       | None              | EICR delivery account service principal client secret               |
-
-#### S3 EICR Bucket
-
-Uses the same authentication defined for the [S3 bucket](#s3-storage-configs)
-
-| Variable Name         | Required | Default Value | Description                                                                                     |
-|-----------------------|----------|---------------|-------------------------------------------------------------------------------------------------|
-| `EICR_S3_ENDPOINT`    | Yes      | None          | S3-compatible storage endpoint URL for EICR delivery storage, must start with `http` or `https` |
-| `EICR_S3_BUCKET_NAME` | Yes      | None          | Bucket name for EICR delivery storage                                                           |
 
 ### NCIRD Delivery Target
 

--- a/upload-server/internal/readme.md
+++ b/upload-server/internal/readme.md
@@ -4,7 +4,8 @@
 
 - package location: `upload-server/internal/middleware/authverification.go`
 
-This middleware provides OAuth 2.0 token verification for incoming requests. It currently supports JWT tokens with the plan to add support for opaque tokens. You can use it to protect either your entire router or individual routes.
+This middleware provides OAuth 2.0 token verification for incoming requests. It currently supports JWT tokens with the plan to add support for opaque tokens. You can use it to protect either your entire router or individual routes.  It first
+tries to read the token from the Authorization request header.  If it doesn't find it there, it will fall back to checking for a user session cookie.
 
 ### Configuration
 

--- a/upload-server/internal/readme.md
+++ b/upload-server/internal/readme.md
@@ -61,11 +61,13 @@ func GetRouter(uploadUrl string, infoUrl string) http.Handler {
 ## User Session Cookies
 This program uses the gorilla/sessions package to instantate and manage user sessions.  Sessions are stored in browser cookies.  These sessions hold access tokens as well as redirect URLs for end users, and are used to protect certain pages of the front end user interface that should only be accessed by an authenticated user.  In addition, it is used to set Authorization headers in requests to the upload server.  The following UX and security features are also implemented:
 
-1. Cookie hashing using a secret key.  This ensures browsers can only send cookies created by the server.
+1. Cookie hashing using a secret key.  This ensures server only accepts cookies created by the server.
 2. Secure and HTTPOnly enabled by default.  This prevents cookies from getting leaked due to XSS and sent unencrypted.
 3. Cookie expires at the same time as their JWT.
 4. Automatic user redirect.  Unauthenticated users are redirected to the login page when trying to access a protected page, and then automatically redirected to their original destination once logged in.
 
 The following are known security risks and future improvements:
 
-1. Proper "login with provider" buttons as opposed to inputting a raw JWT
+1. CSRF: user session cookie can still be intercepted and replayed by bad actor.
+2. Cookie domain setting sets cdc.gov domain.  This allows cookies to be sent to any cdc.gov subdomain, when it should only go to the server itself.
+2. Proper "login with provider" buttons as opposed to inputting a raw JWT

--- a/upload-server/internal/readme.md
+++ b/upload-server/internal/readme.md
@@ -62,12 +62,13 @@ func GetRouter(uploadUrl string, infoUrl string) http.Handler {
 This program uses the gorilla/sessions package to instantate and manage user sessions.  Sessions are stored in browser cookies.  These sessions hold access tokens as well as redirect URLs for end users, and are used to protect certain pages of the front end user interface that should only be accessed by an authenticated user.  In addition, it is used to set Authorization headers in requests to the upload server.  The following UX and security features are also implemented:
 
 1. Cookie hashing using a secret key.  This ensures server only accepts cookies created by the server.
-2. Secure and HTTPOnly enabled by default.  This prevents cookies from getting leaked due to XSS and sent unencrypted.
+2. Secure and HTTPOnly enabled by default.  This prevents cookies from getting leaked due to XSS, and makes it extremely difficult for cookies to get intercepted in MitM attacks.
 3. Cookie expires at the same time as their JWT.
 4. Automatic user redirect.  Unauthenticated users are redirected to the login page when trying to access a protected page, and then automatically redirected to their original destination once logged in.
 
 The following are known security risks and future improvements:
 
-1. CSRF: user session cookie can still be intercepted and replayed by bad actor.
+1. Cookie can still be manipulated by end user.  Poses risk if user device is compromised.  Cookie can be read from user's hard drive and leaked.
 2. Cookie domain setting sets cdc.gov domain.  This allows cookies to be sent to any cdc.gov subdomain, when it should only go to the server itself.
-2. Proper "login with provider" buttons as opposed to inputting a raw JWT
+3. Proper "login with provider" buttons as opposed to inputting a raw JWT
+4. Use an external storage solution like Redis to store the JWT instead of storing it in the cookie itself.  Cookie can instead store a simple session ID.

--- a/upload-server/readme.md
+++ b/upload-server/readme.md
@@ -16,6 +16,7 @@ The DEX Upload API is built on the [tus](https://tus.io) open protocol, which pr
 - Upload multiple files in parallel
 - Configurable authN/authZ middleware
 - Support for distributed file locking to enable horizontal scaling
+- User authentication and scope enforcement with JWTs
 
 ## Folder Structure
 


### PR DESCRIPTION
Adds documentation to the repo's README files to describe the new auth aspect of the system.  Specifically includes:
- New environment variables and configurations
- New behavior of both server and UI

This PR also includes removal of the EICR configuration documentation as that datastream has been offboarded.