### PR TITLE
PHDO-593/bad-uploader-doc-improvements

### DIFF
--- a/tests/bad-uploader/config.go
+++ b/tests/bad-uploader/config.go
@@ -205,7 +205,7 @@ func passthroughString(s string) (string, error) {
 func init() {
 	flag.Float64Var(&size, "size", 5, "the size of the file to upload, in MB")
 	flag.StringVar(&url, "url", fromEnv("UPLOAD_URL", "http://localhost:8080/files", passthroughString), "the upload url for the tus server")
-	flag.StringVar(&infoUrl, "infoUrl", "", "the url for the info endpoint")
+	flag.StringVar(&infoUrl, "info-url", "", "the url for the info endpoint")
 	flag.StringVar(&reportsURL, "reports-url", fromEnv("DEX_REPORTS_URL", "", passthroughString), "the url for the reports graphql server")
 	flag.IntVar(&parallelism, "parallelism", fromEnv("UPLOAD_PARALLELISM", runtime.NumCPU(), strconv.Atoi), "the number of parallel threads to use, defaults to MAXGOPROC when set to < 1.")
 	flag.IntVar(&load, "load", fromEnv("UPLOAD_LOAD", 0, strconv.Atoi), "set the number of files to load, defaults to 0 and adjusts based on benchmark logic")
@@ -250,7 +250,7 @@ func init() {
 	if !flagset["case-dir"] {
 		cases.cases = []TestCase{testcase}
 	}
-	if !flagset["infoUrl"] {
+	if !flagset["info-url"] {
 		serverUrl, _ := path.Split(url)
 		infoUrl, _ = neturl.JoinPath(serverUrl, "info")
 	}

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -83,10 +83,11 @@ func ValidateResults(ctx context.Context, o <-chan *Result) error {
 					// return a specific error and/or check result.  Specific error can have check specific info like upload id and reports
 					err := WithRetry(checkTimeout, r.testCase, uid, check.DoCase)
 					if err != nil {
-						slog.Error("failed post upload check", "error", err, "test case", r.testCase)
+						slog.Error("failed post upload check", "error", err, "test case", r.testCase, "upload ID", uid)
 						logErrors(err, uid)
 						errs = errors.Join(errs, err)
 					} else {
+						slog.Info("Pass", "upload ID", uid)
 						check.OnSuccess()
 					}
 				}(r, check)

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -21,6 +21,11 @@ The tool provides several command-line flags to customize the testing environmen
 | `-duration`        | Specifies the duration of the test (e.g., `30s`, `5m`).                     |
 | `-url`             | URL of the API endpoint to test (default: local server).                    |
 | `-reports-url`     | URL to send test reports to, if needed.                                     |
+| `-sams-url`        | URL of the SAMS oauth token endpoint used to fetch an auth token.                                     |
+| `-username`        | SAMS SYS account username.                                     |
+| `-password`        | SAMS SYS account password.                                     |
+| `-info-url`        | Optional used to overwrite the endpoint used to fetch upload and delivery info.  Defaults to {url}/info.                                     |
+| `-v`               | Enable verbose logging.                                     |
 
 ### Default Values:
 

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -48,7 +48,7 @@ go run ./... -h
 
 ## Usage Examples:
 
-### **Basic Smoke Test (Default)**
+### **Basic Upload Test With Delivery Check (Default)**
 Run a basic test to verify the tool's setup with minimal configuration or for a very basic test of the upload server.
 
 ```bash
@@ -57,7 +57,7 @@ go run ./... -load=1
 
 This command uploads a single 5MB file to the local (default) upload server endpoint.
 
-### **Basic Smoke Test (Alternate)**
+### **Providing an Upload Endpoint URL**
 Run a basic test to verify the tool's setup with minimal configuration or for a very basic test of the upload server at a specified endpoint.
 
 ```bash
@@ -83,3 +83,20 @@ go run ./... -load=10 -size=50 -url=https://upload-api.server:8080/files -report
 ```
 
 This command uploads 10 files, each 50MB in size, and sends the test results to the report server.
+
+## Smoke Testing:
+### Minimal Command for Public URL
+
+```bash
+go run ./... -load=1 -url=https://api.cdc.gov/upload -info-url=https://api.cdc.gov/upload/info -sams-url=https://api.cdc.gov/upload/oauth -username=*** -password=***
+```
+
+**Note that the `info-url` flag is required when testing against the public URL due to the `/upload` path prefix.**
+
+### Minimal Command for Internal URL (AWS EKS Ingress)
+
+```bash
+go run ./... -load=1 -url=https://upload.phdo-eks-prd.cdc.gov/files -sams-url=https://api.cdc.gov/upload/oauth -username=*** -password=***
+```
+
+**Note that SAMS credentials are required for testing gainst the internal URL since JWT authentication is now enabled in all environments.**

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -92,7 +92,7 @@ This command uploads 10 files, each 50MB in size, and sends the test results to 
 ### Minimal Command for Public URL
 
 ```bash
-go run ./... -load=1 -url=https://api.cdc.gov/upload -info-url=https://api.cdc.gov/upload/info -sams-url=https://api.cdc.gov/upload/oauth -username=*** -password=***
+go run ./... -load=1 -url=https://api.cdc.gov/upload -info-url=https://api.cdc.gov/upload/info -sams-url=https://api.cdc.gov/oauth -username=*** -password=***
 ```
 
 **Note that the `info-url` flag is required when testing against the public URL due to the `/upload` path prefix.**
@@ -100,7 +100,7 @@ go run ./... -load=1 -url=https://api.cdc.gov/upload -info-url=https://api.cdc.g
 ### Minimal Command for Internal URL (AWS EKS Ingress)
 
 ```bash
-go run ./... -load=1 -url=https://upload.phdo-eks-prd.cdc.gov/files -sams-url=https://api.cdc.gov/upload/oauth -username=*** -password=***
+go run ./... -load=1 -url=https://upload.phdo-eks-prd.cdc.gov/files -sams-url=https://api.cdc.gov/oauth -username=*** -password=***
 ```
 
 **Note that SAMS credentials are required for testing gainst the internal URL since JWT authentication is now enabled in all environments.**

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -9,6 +9,10 @@ sizes.
 - Verbose test result reporting
 - Run with or without auth
 
+## Setup:
+- Install Golang 1.22 or later
+- Obtain SAMS SYS credentials and get your SYS user added to the DEX API activity in both SAMS Staging and Production environments
+
 ## Configuration Options:
 
 The tool provides several command-line flags to customize the testing environment. Below is a list of key configuration options:
@@ -100,3 +104,4 @@ go run ./... -load=1 -url=https://upload.phdo-eks-prd.cdc.gov/files -sams-url=ht
 ```
 
 **Note that SAMS credentials are required for testing gainst the internal URL since JWT authentication is now enabled in all environments.**
+**Note that these commands can only be run from within the CDC network.**

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -89,6 +89,19 @@ go run ./... -load=10 -size=50 -url=https://upload-api.server:8080/files -report
 This command uploads 10 files, each 50MB in size, and sends the test results to the report server.
 
 ## Smoke Testing:
+The following commands are useful for performing smoke tests against deployed environments.  The following URLs can be used to test both from public internet and internal to CDC network:
+
+| URL               | Environment| Public/Internal |
+|-------------------|------------|-----------------|
+| https://apidev.cdc.gov/upload | dev | Public |
+| https://uploaddev.ocio-eks-dev-ede.cdc.gov/files | dev | Internal |
+| https://apitst.cdc.gov/upload | tst | Public |
+| https://upload.phdo-eks-test.cdc.gov/files | tst | Internal |
+| https://apistg.cdc.gov/upload | stg | Public |
+| https://upload.phdo-eks-stg.cdc.gov/files | stg | Internal |
+| https://api.cdc.gov/upload | prd | Public |
+| https://upload.phdo-eks-prd.cdc.gov/files | prd | Internal |
+
 ### Minimal Command for Public URL
 
 ```bash

--- a/tests/bad-uploader/readme.md
+++ b/tests/bad-uploader/readme.md
@@ -91,16 +91,12 @@ This command uploads 10 files, each 50MB in size, and sends the test results to 
 ## Smoke Testing:
 The following commands are useful for performing smoke tests against deployed environments.  The following URLs can be used to test both from public internet and internal to CDC network:
 
-| URL               | Environment| Public/Internal |
-|-------------------|------------|-----------------|
-| https://apidev.cdc.gov/upload | dev | Public |
-| https://uploaddev.ocio-eks-dev-ede.cdc.gov/files | dev | Internal |
-| https://apitst.cdc.gov/upload | tst | Public |
-| https://upload.phdo-eks-test.cdc.gov/files | tst | Internal |
-| https://apistg.cdc.gov/upload | stg | Public |
-| https://upload.phdo-eks-stg.cdc.gov/files | stg | Internal |
-| https://api.cdc.gov/upload | prd | Public |
-| https://upload.phdo-eks-prd.cdc.gov/files | prd | Internal |
+| URL               | Environment|
+|-------------------|------------|
+| https://apidev.cdc.gov/upload | dev |
+| https://apitst.cdc.gov/upload | tst |
+| https://apistg.cdc.gov/upload | stg |
+| https://api.cdc.gov/upload | prd |
 
 ### Minimal Command for Public URL
 


### PR DESCRIPTION
- Adds more example commands for testing against deployed upload API
- Logging of upload ID on success and failure
- Logging of token request failure