### PR TITLE
Phdo 611/spike upload observability

### DIFF
--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -72,7 +72,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware *m
 		return nil, err
 	}
 	hookHandler.Register(hooks.HookPostCreate, metrics.ActiveUploadIncHook)
-	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook)
+	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook, metrics.UploadDurationObserveHook)
 
 	// initialize tusd handler
 	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath)

--- a/upload-server/cmd/cli/serve.go
+++ b/upload-server/cmd/cli/serve.go
@@ -72,7 +72,7 @@ func Serve(ctx context.Context, appConfig appconfig.AppConfig, authMiddleware *m
 		return nil, err
 	}
 	hookHandler.Register(hooks.HookPostCreate, metrics.ActiveUploadIncHook)
-	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook, metrics.UploadDurationObserveHook)
+	hookHandler.Register(hooks.HookPreFinish, manifestMetrics.Hook, metrics.ActiveUploadDecHook, metrics.UploadSpeedsHook)
 
 	// initialize tusd handler
 	handlerTusd, err := handlertusd.New(store, locker, hookHandler, appConfig.TusdHandlerBasePath)

--- a/upload-server/cmd/cli/setupmetrics.go
+++ b/upload-server/cmd/cli/setupmetrics.go
@@ -11,6 +11,6 @@ import (
 
 // NOTE: pull out manifestMetrics and the dependency on appconfig goes away
 func setupMetrics(m ...prometheus.Collector) {
-	metrics.RegisterMetrics(hooks.MetricsHookErrorsTotal, hooks.MetricsHookInvocationsTotal, metrics.HttpReqs, metrics.OpenConnections, metrics.ActiveUploads, metrics.UploadDurationSeconds)
+	metrics.RegisterMetrics(hooks.MetricsHookErrorsTotal, hooks.MetricsHookInvocationsTotal, metrics.HttpReqs, metrics.OpenConnections, metrics.ActiveUploads, metrics.UploadSpeedsMegabytes)
 	metrics.RegisterMetrics(m...)
 } // setupMetrics

--- a/upload-server/cmd/cli/setupmetrics.go
+++ b/upload-server/cmd/cli/setupmetrics.go
@@ -11,6 +11,6 @@ import (
 
 // NOTE: pull out manifestMetrics and the dependency on appconfig goes away
 func setupMetrics(m ...prometheus.Collector) {
-	metrics.RegisterMetrics(hooks.MetricsHookErrorsTotal, hooks.MetricsHookInvocationsTotal, metrics.HttpReqs, metrics.OpenConnections, metrics.ActiveUploads)
+	metrics.RegisterMetrics(hooks.MetricsHookErrorsTotal, hooks.MetricsHookInvocationsTotal, metrics.HttpReqs, metrics.OpenConnections, metrics.ActiveUploads, metrics.UploadDurationSeconds)
 	metrics.RegisterMetrics(m...)
 } // setupMetrics

--- a/upload-server/internal/metrics/uploads.go
+++ b/upload-server/internal/metrics/uploads.go
@@ -1,6 +1,10 @@
 package metrics
 
 import (
+	"errors"
+	"log/slog"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tus/tusd/v2/pkg/handler"
 	"github.com/tus/tusd/v2/pkg/hooks"
@@ -12,8 +16,16 @@ var ActiveUploads = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "Current number of active uploads",
 }) // .metricsOpenConnections
 
+var UploadDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name: "dex_server_upload_duration_seconds",
+	Help: "File upload duration distribution in seconds",
+	// TODO parameterize this with a helper function; can eventually be driven by config.
+	Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 180, 240, 300, 450, 600},
+})
+
 var DefaultMetrics = []prometheus.Collector{
 	ActiveUploads,
+	UploadDurationSeconds,
 }
 
 func ActiveUploadIncHook(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
@@ -22,6 +34,35 @@ func ActiveUploadIncHook(event handler.HookEvent, resp hooks.HookResponse) (hook
 }
 func ActiveUploadDecHook(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
 	ActiveUploads.Dec()
+	return resp, nil
+}
+
+func UploadDurationObserveHook(event handler.HookEvent, resp hooks.HookResponse) (hooks.HookResponse, error) {
+	tuid := event.Upload.ID
+	if resp.ChangeFileInfo.ID != "" {
+		tuid = resp.ChangeFileInfo.ID
+	}
+	if tuid == "" {
+		return resp, errors.New("no Upload ID defined")
+	}
+
+	manifest := event.Upload.MetaData
+	start, ok := manifest["dex_ingest_datetime"]
+	if !ok {
+		slog.Warn("unable to observe upload duration; no start time found in manifest", "uploadId", tuid)
+		return resp, nil
+	}
+
+	startTime, err := time.Parse(time.RFC3339Nano, start)
+	if err != nil {
+		slog.Warn("unable to observe upload duration; unable to parse timestamp", "timestamp", start, "uploadId", tuid)
+		return resp, nil
+	}
+
+	duration := time.Since(startTime).Seconds()
+	slog.Info("observed upload duration", "duration", duration)
+	UploadDurationSeconds.Observe(duration)
+
 	return resp, nil
 }
 


### PR DESCRIPTION
This is a quick addition to our prometheus metrics to add a histogram for counting upload speeds in megabytes per second.  This histogram can later be used in grafana/prometheus to show median upload speed in MB/sec.  This will give a good idea of overall upload performance for users of the Upload API.  The higher the speed, the faster files can get uploaded, which likely results in a happier user.