### PR TITLE
Phdo 609/bad uploader delivery latency

### DIFF
--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -15,6 +15,7 @@ import (
 type LoadTestResult struct {
 	SuccessfulUploads    int32
 	SuccessfulDeliveries int32
+	DeliveryDurations    []time.Duration
 	SuccessfulEventSets  int32
 	TotalDuration        time.Duration
 }
@@ -133,6 +134,7 @@ Files delivered: %d/%d
 	}
 
 	fmt.Printf("Duration: %f seconds\r\n", testResult.TotalDuration.Seconds())
+	printDeliveryMetrics()
 	fmt.Println("**********************************")
 }
 
@@ -162,6 +164,29 @@ func printValidationErrors(errs error) {
 			printValidationErrors(err)
 		}
 	}
+}
+
+func printDeliveryMetrics() {
+	if len(testResult.DeliveryDurations) == 0 {
+		return
+	}
+
+	var min, max, sum, avg time.Duration
+	for _, dur := range testResult.DeliveryDurations {
+		if min == 0 || dur < min {
+			min = dur
+		}
+		if dur > max {
+			max = dur
+		}
+		sum += dur
+	}
+
+	avg = time.Duration(int64(sum) / int64(len(testResult.DeliveryDurations)))
+
+	fmt.Printf("Average delivery duration: %s\n", avg)
+	fmt.Printf("Max delivery duration: %s\n", max)
+	fmt.Printf("Min delivery duration: %s\n", min)
 }
 
 func logErrors(err error, uploadId string) {

--- a/tests/bad-uploader/main.go
+++ b/tests/bad-uploader/main.go
@@ -184,9 +184,9 @@ func printDeliveryMetrics() {
 
 	avg = time.Duration(int64(sum) / int64(len(testResult.DeliveryDurations)))
 
-	fmt.Printf("Average delivery duration: %s\n", avg)
-	fmt.Printf("Max delivery duration: %s\n", max)
-	fmt.Printf("Min delivery duration: %s\n", min)
+	fmt.Printf("Average delivery duration: %s\n", avg.Round(time.Millisecond))
+	fmt.Printf("Max delivery duration: %s\n", max.Round(time.Millisecond))
+	fmt.Printf("Min delivery duration: %s\n", min.Round(time.Millisecond))
 }
 
 func logErrors(err error, uploadId string) {


### PR DESCRIPTION
Minor patch to the bad uploader to track delivery latency for all files uploaded in a load test run.  The run records a delivery latency for a given upload by taking the difference between the delivery timestamp and the last chunk received timestamp.  During the print result step of the run, it iterates through all recorded durations and finds the min and max.  It also finds the average by summing up all durations and dividing by the number of them recorded.