### PR TITLE
Phdo 713/active goroutine thresh

### DIFF
--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -159,7 +159,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "avg by(target) (dex_server_active_deliveries{job=\"upload\"})",
+          "expr": "sum by(target) (dex_server_active_deliveries{job=\"upload\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",

--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -181,7 +181,10 @@
           "color": {
             "mode": "thresholds"
           },
+          "fieldMinMax": false,
           "mappings": [],
+          "max": 100000,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -190,11 +193,15 @@
               },
               {
                 "color": "#EAB839",
-                "value": 500
+                "value": 50000
               },
               {
                 "color": "red",
-                "value": 750
+                "value": 75000
+              },
+              {
+                "color": "dark-red",
+                "value": 100000
               }
             ]
           }
@@ -219,7 +226,7 @@
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
+        "showThresholdLabels": true,
         "showThresholdMarkers": true,
         "sizing": "auto"
       },


### PR DESCRIPTION
Minor patch to refine the PHDO Snapshot Grafana dashboard.
- Update active goroutine threshold: 50,000 for yellow; 75,000 for red; 100,000 for dark red
- Use SUM instead of AVG for active delivery aggregate function

<img width="233" alt="image" src="https://github.com/user-attachments/assets/d7b08318-d3e5-44c3-a42d-35e26ab905e1" />
