### PR TITLE
Phdo 729/bugfix delivery failed metric

### DIFF
--- a/upload-server/cmd/cli/delivery.go
+++ b/upload-server/cmd/cli/delivery.go
@@ -44,7 +44,7 @@ func RegisterAllSourcesAndDestinations(ctx context.Context, appConfig appconfig.
 		}
 		// init delivery metrics
 		metrics.ActiveDeliveries.With(prometheus.Labels{"target": t.Name}).Set(0)
-		metrics.DeliveryTotals.With(prometheus.Labels{"target": t.Name, "result": "failure"}).Add(0)
+		metrics.DeliveryTotals.With(prometheus.Labels{"target": t.Name, "result": metrics.DeliveryResultFailed}).Add(0)
 	}
 	slog.Info("registering destinations", "targets", delivery.Targets)
 

--- a/upload-server/cmd/cli/metrics.go
+++ b/upload-server/cmd/cli/metrics.go
@@ -23,6 +23,4 @@ func setupMetrics(m ...prometheus.Collector) {
 		metrics.DeliveryTotals,
 	)
 	metrics.RegisterMetrics(m...)
-
-	// metrics.DefaultPoller.Start(ctx, pollInterval)
 } // setupMetrics

--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -296,7 +296,7 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "sum by(target) (dex_server_deliveries_total{job=\"upload\", result=\"failure\"})",
+          "expr": "sum by(target) (dex_server_deliveries_total{job=\"upload\", result=\"failed\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",

--- a/upload-server/internal/metrics/delivery.go
+++ b/upload-server/internal/metrics/delivery.go
@@ -2,6 +2,10 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+const DeliveryResultStarted = "started"
+const DeliveryResultCompleted = "completed"
+const DeliveryResultFailed = "failed"
+
 var ActiveDeliveries = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "dex_server_active_deliveries",
 	Help: "Gauge showing number of deliveries in progress",

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -2,6 +2,7 @@ package postprocessing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -69,20 +70,20 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	}
 
 	metrics.ActiveDeliveries.With(prometheus.Labels{"target": e.DestinationTarget}).Inc()
-	metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": "started"}).Inc()
+	metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": metrics.DeliveryResultStarted}).Inc()
 	uri, err := delivery.Deliver(ctx, e.UploadId, e.Path, src, d)
 	metrics.ActiveDeliveries.With(prometheus.Labels{"target": e.DestinationTarget}).Dec()
-
+	err = errors.New("simulate delivery failure")
 	if err != nil {
 		logger.Error("failed to deliver file", "target", uri, "error", err)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{
 			Level:   reports.IssueLevelError,
 			Message: err.Error(),
 		})
-		metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": "failed"}).Inc()
+		metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": metrics.DeliveryResultFailed}).Inc()
 		return err
 	}
-	metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": "completed"}).Inc()
+	metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": metrics.DeliveryResultCompleted}).Inc()
 	logger.Info("file delivered", "event", e) // Is this necessary?
 
 	m, err := src.GetMetadata(ctx, e.UploadId)

--- a/upload-server/internal/postprocessing/postprocessor.go
+++ b/upload-server/internal/postprocessing/postprocessor.go
@@ -2,7 +2,6 @@ package postprocessing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -73,7 +72,6 @@ func ProcessFileReadyEvent(ctx context.Context, e *event.FileReady) error {
 	metrics.DeliveryTotals.With(prometheus.Labels{"target": e.DestinationTarget, "result": metrics.DeliveryResultStarted}).Inc()
 	uri, err := delivery.Deliver(ctx, e.UploadId, e.Path, src, d)
 	metrics.ActiveDeliveries.With(prometheus.Labels{"target": e.DestinationTarget}).Dec()
-	err = errors.New("simulate delivery failure")
 	if err != nil {
 		logger.Error("failed to deliver file", "target", uri, "error", err)
 		rb.SetStatus(reports.StatusFailed).AppendIssue(reports.ReportIssue{

--- a/upload-server/testing/cli_test.go
+++ b/upload-server/testing/cli_test.go
@@ -325,6 +325,17 @@ func TestRouteFileNotFound(t *testing.T) {
 	}
 }
 
+func TestMetricsEndpointSuccess(t *testing.T) {
+	client := ts.Client()
+	resp, err := client.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Error("expected 200 but got", resp.StatusCode)
+	}
+}
+
 // UI Tests
 func TestLandingPage(t *testing.T) {
 	client := testUIServer.Client()


### PR DESCRIPTION
Patch to fix the failed delivery counter not being tracked correctly.  This was due to an inconsistency in the label name that was being incremented, and the one that Grafana was looking for.