### PR TITLE
Phdo 683/dashboard time since last delivery

### DIFF
--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -443,7 +443,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 6
       },
@@ -511,6 +511,109 @@
             },
             "renameByName": {
               "upload_manifest_count_timestamp_milliseconds": "Time Since"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 18,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "delivery_completed_timestamp_milliseconds",
+          "instant": true,
+          "legendFormat": "{{target}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Time Since Last Successful Delivery",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "valueLabel": "__name__"
+          }
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "edav": false
+            },
+            "includeByName": {},
+            "indexByName": {
+              "Time": 0,
+              "delivery_completed_timestamp_milliseconds": 2,
+              "target": 1
+            },
+            "renameByName": {
+              "delivery_completed_timestamp_milliseconds": "Time Since",
+              "target": "Target"
             }
           }
         }

--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -528,7 +528,7 @@
             "mode": "thresholds"
           },
           "custom": {
-            "align": "auto",
+            "align": "left",
             "cellOptions": {
               "type": "auto"
             },
@@ -549,7 +549,19 @@
           },
           "unit": "dateTimeFromNow"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Target"
+            },
+            "properties": [
+              {
+                "id": "unit"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 7,
@@ -580,6 +592,7 @@
           "editorMode": "code",
           "exemplar": false,
           "expr": "delivery_completed_timestamp_milliseconds",
+          "format": "time_series",
           "instant": true,
           "legendFormat": "{{target}}",
           "range": false,
@@ -591,7 +604,9 @@
         {
           "id": "labelsToFields",
           "options": {
-            "valueLabel": "__name__"
+            "keepLabels": [
+              "target"
+            ]
           }
         },
         {

--- a/upload-server/configs/local/prometheus/rules.yml
+++ b/upload-server/configs/local/prometheus/rules.yml
@@ -11,3 +11,12 @@ groups:
           (
             upload_manifest_count_timestamp_milliseconds offset 1m
           )
+      - record: delivery_completed_timestamp_milliseconds
+        expr: |
+          (
+            (timestamp(sum by(target) (increase(dex_server_deliveries_total{result="completed"}[1m])) > 0)) * 1000
+          )
+          or
+          (
+            delivery_completed_timestamp_milliseconds offset 1m
+          )


### PR DESCRIPTION
This patch adds a panel to the snapshot dashboard to show a table for time since last successful delivery for each unique delivery target.  This required a new prometheus rule to be added to pre-calculate the timestamp of the increase in the delivery complete counter.

<img width="673" alt="image" src="https://github.com/user-attachments/assets/1a2cc7f2-2e31-49b1-8a82-f564f96ff977" />
