### PR TITLE
PHDO-693 Active Upload Alternative Metric

### DIFF
--- a/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
+++ b/upload-server/configs/local/grafana/provisioning/dashboards/dex.json
@@ -40,12 +40,15 @@
         "type": "prometheus",
         "uid": "prometheus-datasource"
       },
+      "description": "Gauge to show the number of files that have been started over a time window of 1 hour.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -53,8 +56,16 @@
                 "color": "green"
               },
               {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
                 "color": "red",
                 "value": 80
+              },
+              {
+                "color": "dark-red",
+                "value": 100
               }
             ]
           }
@@ -67,7 +78,7 @@
         "x": 0,
         "y": 1
       },
-      "id": 3,
+      "id": 20,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
@@ -79,18 +90,23 @@
           "fields": "",
           "values": false
         },
-        "showThresholdLabels": false,
+        "showThresholdLabels": true,
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
       "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus-datasource"
+          },
           "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "sum by(job) (dex_server_active_uploads{job=\"upload\"})",
+          "editorMode": "code",
+          "expr": "round(sum(increase(tusd_uploads_created[1h])) - sum(increase(tusd_uploads_finished[1h])))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
+          "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",


### PR DESCRIPTION
Problem: The metric `dex_server_active_uploads` gets frequently out of sync in distributed scenarios where there are multiple replicas of this service.  In these situations, race conditions happen that make the counter report inaccurate values, such as negative values.  In addition, this metric does not take into account uploads that have been abandoned.  In the grafana dashboard gauge, this gives the false impression that an upload is in progress, when really it will never finish.  Overall, this is a consequence of Tusd as it doesn't keep track of uploads that haven't received a chunk after a certain amount of time, or have otherwise gone stale.

Mitigation: To mitigate this, we use a different promQL query that relies on two counters that are already being emitted by Tusd: `tusd_uploads_created` and `tusd_uploads_finished`.  These are counters that increment when an upload initiates and when the last chunk is received.  Naturally, taking the difference of these counts gives us uploads in progress:
```
sum(tusd_upload_created) - sum(tusd_uploads_finished)
```
This approach fixes the first problem of race conditions sense these metrics are counts instead of gauges.  However, it is still is susceptible to the second problem of counting abandoned uploads.  To account for this, we'll use the `increase` function where we can specify a time window for the counts that we want to track.  We can set this time window to one that matches our SLA of 1 hour.  With that, prometheus will not count increases that are older than 1 hour.  The counters themselves will still show a greater count for uploads started, but prometheus will ignore those increases after an hour.  This brings us to our final query:
```
round(sum(increase(tusd_uploads_created[1h])) - sum(increase(tusd_uploads_finished[1h])))
```